### PR TITLE
fix: Allow 2 blank lines in markdown

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -3,5 +3,7 @@ config:
   line-length: false # MD013
   no-duplicate-heading: false # MD024
   reference-links-images: false # MD052
+  no-multiple-blanks:
+    maximum: 2
 ignores:
   - .github/copilot-instructions.md


### PR DESCRIPTION
release-please likes it's blank lines

Signed-off-by: Dan Webb <dan.webb@damacus.io>
