### PR TITLE
fix: fan speed list for T2181

### DIFF
--- a/custom_components/robovac/vacuums/T2181.py
+++ b/custom_components/robovac/vacuums/T2181.py
@@ -41,7 +41,7 @@ class T2181(RobovacModelDetails):
         RobovacCommand.RETURN_HOME: 101,
         RobovacCommand.FAN_SPEED: {
             "code": 102,
-            "values": ["Quiet", "Standard", "Turbo", "Max"],
+            "values": ["Quiet", "Turbo", "Max"],
         },
         RobovacCommand.LOCATE: 103,
         RobovacCommand.BATTERY: 104,


### PR DESCRIPTION
Fix fan speed list for T2181. Exception is the max turbo + fan speed from the App. Couldn't find the right name for it. Tried a lot of combination, but the rest are working.

Fix: #85 