### PR TITLE
fix: use model-specific code for start commands

### DIFF
--- a/custom_components/robovac/vacuum.py
+++ b/custom_components/robovac/vacuum.py
@@ -697,7 +697,9 @@ class RoboVacEntity(StateVacuumEntity):
             _LOGGER.error("Cannot start vacuum: vacuum not initialized")
             return
 
-        await self.vacuum.async_set({"5": self.mode})
+        # Use _get_dps_code to get the correct model-specific code for MODE
+        mode_code = self._get_dps_code("MODE")
+        await self.vacuum.async_set({mode_code: self.mode})
 
     async def async_pause(self, **kwargs: Any) -> None:
         """Pause the vacuum cleaner.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -120,3 +120,58 @@ def mock_g30_data():
         CONF_DESCRIPTION: "RoboVac G30",
         CONF_MAC: "aa:bb:cc:dd:ee:00",
     }
+
+
+@pytest.fixture
+def mock_l60():
+    """Create a mock L60 RoboVac device."""
+    mock = MagicMock()
+    # Set up common return values
+    mock.getHomeAssistantFeatures.return_value = (
+        VacuumEntityFeature.BATTERY
+        | VacuumEntityFeature.FAN_SPEED
+        | VacuumEntityFeature.LOCATE
+        | VacuumEntityFeature.PAUSE
+        | VacuumEntityFeature.RETURN_HOME
+        | VacuumEntityFeature.SEND_COMMAND
+        | VacuumEntityFeature.START
+        | VacuumEntityFeature.STATE
+        | VacuumEntityFeature.STOP
+    )
+    mock.getRoboVacFeatures.return_value = (
+        RoboVacEntityFeature.DO_NOT_DISTURB | RoboVacEntityFeature.BOOST_IQ
+    )
+    mock.getFanSpeeds.return_value = ["No Suction", "Standard", "Boost IQ", "Max"]
+    mock._dps = {}
+
+    # Set up model-specific DPS codes for L60 (T2278)
+    mock.getDpsCodes.return_value = {
+        "MODE": "152",
+        "STATUS": "173",
+        "RETURN_HOME": "153",
+        "FAN_SPEED": "154",
+        "LOCATE": "153",
+        "BATTERY_LEVEL": "172",
+        "ERROR_CODE": "169"
+    }
+
+    # Set up async methods with AsyncMock
+    mock.async_get = AsyncMock(return_value=mock._dps)
+    mock.async_set = AsyncMock(return_value=True)
+    mock.async_disable = AsyncMock(return_value=True)
+
+    return mock
+
+
+@pytest.fixture
+def mock_l60_data():
+    """Create mock L60 vacuum configuration data."""
+    return {
+        CONF_NAME: "Test L60",
+        CONF_ID: "test_l60_id",
+        CONF_MODEL: "T2278",  # L60 model
+        CONF_IP_ADDRESS: "192.168.1.102",
+        CONF_ACCESS_TOKEN: "test_access_token_l60",
+        CONF_DESCRIPTION: "eufy Clean L60 Hybrid SES",
+        CONF_MAC: "aa:bb:cc:dd:ee:11",
+    }

--- a/tests/test_vacuum/test_vacuum_commands.py
+++ b/tests/test_vacuum/test_vacuum_commands.py
@@ -75,7 +75,7 @@ async def test_async_start_model_specific(mock_robovac, mock_vacuum_data, mock_l
         await entity.async_start()
         mock_robovac.async_set.assert_called_once_with({"5": "auto"})
         mock_robovac.async_set.reset_mock()
-    
+
     # Test with L60 model (should use code "152")
     # Mock should return "152" for the MODE code
     mock_l60.getDpsCodes.return_value = {"MODE": "152"}

--- a/tests/test_vacuum/test_vacuum_commands.py
+++ b/tests/test_vacuum/test_vacuum_commands.py
@@ -67,6 +67,27 @@ async def test_async_start(mock_robovac, mock_vacuum_data):
 
 
 @pytest.mark.asyncio
+async def test_async_start_model_specific(mock_robovac, mock_vacuum_data, mock_l60, mock_l60_data):
+    """Test that async_start uses the correct code for different models."""
+    # Test with standard model (should use code "5")
+    with patch("custom_components.robovac.vacuum.RoboVac", return_value=mock_robovac):
+        entity = RoboVacEntity(mock_vacuum_data)
+        await entity.async_start()
+        mock_robovac.async_set.assert_called_once_with({"5": "auto"})
+        mock_robovac.async_set.reset_mock()
+    
+    # Test with L60 model (should use code "152")
+    # Mock should return "152" for the MODE code
+    mock_l60.getDpsCodes.return_value = {"MODE": "152"}
+    with patch("custom_components.robovac.vacuum.RoboVac", return_value=mock_l60):
+        entity = RoboVacEntity(mock_l60_data)
+        await entity.async_start()
+        # This will fail with the current implementation because it always uses code "5"
+        # The fix will make it use "152" for L60 models
+        mock_l60.async_set.assert_called_once_with({"152": "auto"})
+
+
+@pytest.mark.asyncio
 async def test_async_pause(mock_robovac, mock_vacuum_data):
     """Test the async_pause method."""
     # Arrange

--- a/uv.lock
+++ b/uv.lock
@@ -4,5 +4,5 @@ requires-python = ">=3.13.0"
 
 [[package]]
 name = "robovac"
-version = "1.2.3"
+version = "1.3.0"
 source = { editable = "." }


### PR DESCRIPTION
Should go towards fixing #29 