### PR TITLE
fix: (refactor) replace TUYA_CODES references with TuyaCodes class

### DIFF
--- a/analyze_model_dps.py
+++ b/analyze_model_dps.py
@@ -13,7 +13,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 # Import the necessary modules
 from custom_components.robovac.robovac import RoboVac
-from custom_components.robovac.vacuum import TUYA_CODES
+from custom_components.robovac.vacuums.base import TuyaCodes
 from custom_components.robovac.vacuums import ROBOVAC_MODELS
 
 
@@ -22,18 +22,18 @@ def analyze_model_dps_codes() -> None:
     # Dictionary to store results
     model_dps_analysis = {}
 
-    # Default codes from TUYA_CODES
+    # Default codes from TuyaCodes
     default_codes = {
-        "STATE": TUYA_CODES.STATUS,
-        "BATTERY_LEVEL": TUYA_CODES.BATTERY_LEVEL,
-        "ERROR_CODE": TUYA_CODES.ERROR_CODE,
-        "MODE": TUYA_CODES.MODE,
-        "FAN_SPEED": TUYA_CODES.FAN_SPEED,
-        "CLEANING_AREA": TUYA_CODES.CLEANING_AREA,
-        "CLEANING_TIME": TUYA_CODES.CLEANING_TIME,
-        "AUTO_RETURN": TUYA_CODES.AUTO_RETURN,
-        "DO_NOT_DISTURB": TUYA_CODES.DO_NOT_DISTURB,
-        "BOOST_IQ": TUYA_CODES.BOOST_IQ,
+        "STATE": TuyaCodes.STATUS,
+        "BATTERY_LEVEL": TuyaCodes.BATTERY_LEVEL,
+        "ERROR_CODE": TuyaCodes.ERROR_CODE,
+        "MODE": TuyaCodes.MODE,
+        "FAN_SPEED": TuyaCodes.FAN_SPEED,
+        "CLEANING_AREA": TuyaCodes.CLEANING_AREA,
+        "CLEANING_TIME": TuyaCodes.CLEANING_TIME,
+        "AUTO_RETURN": TuyaCodes.AUTO_RETURN,
+        "DO_NOT_DISTURB": TuyaCodes.DO_NOT_DISTURB,
+        "BOOST_IQ": TuyaCodes.BOOST_IQ,
     }
 
     # Check each model

--- a/custom_components/robovac/sensor.py
+++ b/custom_components/robovac/sensor.py
@@ -9,7 +9,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.device_registry import DeviceInfo
 
 from .const import CONF_VACS, DOMAIN, REFRESH_RATE
-from .vacuum import TUYA_CODES
+from .vacuums.base import TuyaCodes
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -63,7 +63,7 @@ class RobovacBatterySensor(SensorEntity):
         try:
             vacuum_entity = self.hass.data[DOMAIN][CONF_VACS].get(self.robovac_id)
             if vacuum_entity and vacuum_entity.tuyastatus:
-                self._attr_native_value = vacuum_entity.tuyastatus.get(TUYA_CODES.BATTERY_LEVEL)
+                self._attr_native_value = vacuum_entity.tuyastatus.get(TuyaCodes.BATTERY_LEVEL)
                 self._attr_available = True
             else:
                 _LOGGER.debug("Vacuum entity or status not available for %s", self.robovac_id)

--- a/custom_components/robovac/vacuum.py
+++ b/custom_components/robovac/vacuum.py
@@ -48,9 +48,9 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import CONF_VACS, DOMAIN, PING_RATE, REFRESH_RATE, TIMEOUT
 from .errors import getErrorMessage
+from .vacuums.base import RobovacCommand, RoboVacEntityFeature, TuyaCodes, TUYA_CONSUMABLES_CODES
 from .robovac import ModelNotSupportedException, RoboVac
 from .tuyalocalapi import TuyaException
-from .vacuums.base import RoboVacEntityFeature
 
 ATTR_BATTERY_ICON = "battery_icon"
 ATTR_ERROR = "error"
@@ -70,26 +70,6 @@ ATTR_MODE = "mode"
 _LOGGER = logging.getLogger(__name__)
 SCAN_INTERVAL = timedelta(seconds=REFRESH_RATE)
 UPDATE_RETRIES = 3
-
-
-class TUYA_CODES(StrEnum):
-    START_PAUSE = "2"
-    DIRECTION = "3"
-    MODE = "5"
-    STATUS = "15"
-    RETURN_HOME = "101"
-    FAN_SPEED = "102"
-    LOCATE = "103"
-    BATTERY_LEVEL = "104"
-    ERROR_CODE = "106"
-    DO_NOT_DISTURB = "107"
-    CLEANING_TIME = "109"
-    CLEANING_AREA = "110"
-    BOOST_IQ = "118"
-    AUTO_RETURN = "135"
-
-
-TUYA_CONSUMABLES_CODES = ["142", "116"]
 
 
 async def async_setup_entry(
@@ -510,17 +490,13 @@ class RoboVacEntity(StateVacuumEntity):
             The DPS code as a string
         """
         if self.vacuum is None:
-            return getattr(TUYA_CODES, code_name, "")
+            return getattr(TuyaCodes, code_name, "")
 
-        # Get model-specific DPS codes
         model_dps_codes = self.vacuum.getDpsCodes()
-
-        # Return model-specific code if available, otherwise use default
         if code_name in model_dps_codes:
             return model_dps_codes[code_name]
 
-        # Fall back to default codes
-        return getattr(TUYA_CODES, code_name, "")
+        return getattr(TuyaCodes, code_name, "")
 
     def _get_consumables_codes(self) -> list[str]:
         """Get the consumables DPS codes.
@@ -668,10 +644,11 @@ class RoboVacEntity(StateVacuumEntity):
             _LOGGER.error("Cannot locate vacuum: vacuum not initialized")
             return
 
-        if self.tuyastatus is not None and self.tuyastatus.get("103"):
-            await self.vacuum.async_set({"103": False})
+        locate_code = self._get_dps_code("LOCATE")
+        if self.tuyastatus is not None and self.tuyastatus.get(locate_code):
+            await self.vacuum.async_set({locate_code: False})
         else:
-            await self.vacuum.async_set({"103": True})
+            await self.vacuum.async_set({locate_code: True})
 
     async def async_return_to_base(self, **kwargs: Any) -> None:
         """Set the vacuum cleaner to return to the dock.
@@ -684,7 +661,8 @@ class RoboVacEntity(StateVacuumEntity):
             _LOGGER.error("Cannot return to base: vacuum not initialized")
             return
 
-        await self.vacuum.async_set({"101": True})
+        return_home_code = self._get_dps_code("RETURN_HOME")
+        await self.vacuum.async_set({return_home_code: True})
 
     async def async_start(self, **kwargs: Any) -> None:
         """Start the vacuum cleaner in auto mode.
@@ -711,7 +689,8 @@ class RoboVacEntity(StateVacuumEntity):
             _LOGGER.error("Cannot pause vacuum: vacuum not initialized")
             return
 
-        await self.vacuum.async_set({"2": False})
+        start_pause_code = self._get_dps_code("START_PAUSE")
+        await self.vacuum.async_set({start_pause_code: False})
 
     async def async_stop(self, **kwargs: Any) -> None:
         """Stop the vacuum cleaner.
@@ -732,7 +711,8 @@ class RoboVacEntity(StateVacuumEntity):
             _LOGGER.error("Cannot clean spot: vacuum not initialized")
             return
 
-        await self.vacuum.async_set({"5": "Spot"})
+        mode_code = self._get_dps_code("MODE")
+        await self.vacuum.async_set({mode_code: "Spot"})
 
     async def async_set_fan_speed(self, fan_speed: str, **kwargs: Any) -> None:
         """Set fan speed.
@@ -752,7 +732,8 @@ class RoboVacEntity(StateVacuumEntity):
             fan_speed = "Boost_IQ"
         elif fan_speed == "Pure":
             fan_speed = "Quiet"
-        await self.vacuum.async_set({"102": fan_speed})
+        fan_speed_code = self._get_dps_code("FAN_SPEED")
+        await self.vacuum.async_set({fan_speed_code: fan_speed})
 
     async def async_send_command(
         self, command: str, params: dict[str, Any] | list[Any] | None = None, **kwargs: Any
@@ -769,32 +750,36 @@ class RoboVacEntity(StateVacuumEntity):
             _LOGGER.error("Cannot send command: vacuum not initialized")
             return
 
+        mode_code = self._get_dps_code("MODE")
         if command == "edgeClean":
-            await self.vacuum.async_set({"5": "Edge"})
+            await self.vacuum.async_set({mode_code: "Edge"})
         elif command == "smallRoomClean":
-            await self.vacuum.async_set({"5": "SmallRoom"})
+            await self.vacuum.async_set({mode_code: "SmallRoom"})
         elif command == "autoClean":
-            await self.vacuum.async_set({"5": "auto"})
+            await self.vacuum.async_set({mode_code: "auto"})
         elif command == "autoReturn":
             # Handle both boolean and string values
+            auto_return_code = self._get_dps_code("AUTO_RETURN")
             if self._is_value_true(self.auto_return):
-                await self.vacuum.async_set({"135": False})
+                await self.vacuum.async_set({auto_return_code: False})
             else:
-                await self.vacuum.async_set({"135": True})
+                await self.vacuum.async_set({auto_return_code: True})
         elif command == "doNotDisturb":
             # Handle both boolean and string values
+            do_not_disturb_code = self._get_dps_code("DO_NOT_DISTURB")
             if self._is_value_true(self.do_not_disturb):
                 await self.vacuum.async_set({"139": "MEQ4MDAwMDAw"})
-                await self.vacuum.async_set({"107": False})
+                await self.vacuum.async_set({do_not_disturb_code: False})
             else:
                 await self.vacuum.async_set({"139": "MTAwMDAwMDAw"})
-                await self.vacuum.async_set({"107": True})
+                await self.vacuum.async_set({do_not_disturb_code: True})
         elif command == "boostIQ":
             # Handle both boolean and string values
+            boost_iq_code = self._get_dps_code("BOOST_IQ")
             if self._is_value_true(self.boost_iq):
-                await self.vacuum.async_set({"118": False})
+                await self.vacuum.async_set({boost_iq_code: False})
             else:
-                await self.vacuum.async_set({"118": True})
+                await self.vacuum.async_set({boost_iq_code: True})
         elif command == "roomClean" and params is not None and isinstance(params, dict):
             # Get room IDs and count from params, with defaults
             room_ids = params.get("roomIds", [1])
@@ -812,6 +797,8 @@ class RoboVacEntity(StateVacuumEntity):
             json_str = json.dumps(method_call, separators=(",", ":"))
             base64_str = base64.b64encode(json_str.encode("utf8")).decode("utf8")
             _LOGGER.info("roomClean call %s", json_str)
+            # Note: 124 is a special code for room clean that might need model-specific handling
+            # Currently no direct mapping in TuyaCodes
             await self.vacuum.async_set({"124": base64_str})
 
     async def async_will_remove_from_hass(self) -> None:

--- a/custom_components/robovac/vacuum.py
+++ b/custom_components/robovac/vacuum.py
@@ -797,9 +797,7 @@ class RoboVacEntity(StateVacuumEntity):
             json_str = json.dumps(method_call, separators=(",", ":"))
             base64_str = base64.b64encode(json_str.encode("utf8")).decode("utf8")
             _LOGGER.info("roomClean call %s", json_str)
-            # Note: 124 is a special code for room clean that might need model-specific handling
-            # Currently no direct mapping in TuyaCodes
-            await self.vacuum.async_set({"124": base64_str})
+            await self.vacuum.async_set({TuyaCodes.ROOM_CLEAN: base64_str})
 
     async def async_will_remove_from_hass(self) -> None:
         """Handle removal from Home Assistant."""

--- a/custom_components/robovac/vacuums/base.py
+++ b/custom_components/robovac/vacuums/base.py
@@ -36,7 +36,33 @@ class RobovacCommand(StrEnum):
     CONSUMABLES = "consumables"
 
 
+class TuyaCodes(StrEnum):
+    """Default DPS codes for Tuya-based vacuums.
+
+    These codes can be overridden in model-specific implementations.
+    """
+    START_PAUSE = "2"
+    DIRECTION = "3"
+    MODE = "5"
+    STATUS = "15"
+    RETURN_HOME = "101"
+    FAN_SPEED = "102"
+    LOCATE = "103"
+    BATTERY_LEVEL = "104"
+    ERROR_CODE = "106"
+    DO_NOT_DISTURB = "107"
+    CLEANING_TIME = "109"
+    CLEANING_AREA = "110"
+    BOOST_IQ = "118"
+    AUTO_RETURN = "135"
+
+
+# Default consumables DPS codes
+TUYA_CONSUMABLES_CODES = ["142", "116"]
+
+
 class RobovacModelDetails(Protocol):
     homeassistant_features: int
     robovac_features: int
     commands: Dict[RobovacCommand, Any]
+    dps_codes: Dict[str, str] = {}  # Optional model-specific DPS codes

--- a/custom_components/robovac/vacuums/base.py
+++ b/custom_components/robovac/vacuums/base.py
@@ -54,6 +54,7 @@ class TuyaCodes(StrEnum):
     CLEANING_TIME = "109"
     CLEANING_AREA = "110"
     BOOST_IQ = "118"
+    ROOM_CLEAN = "124"
     AUTO_RETURN = "135"
 
 

--- a/tests/test_vacuum/test_dps_command_mapping.py
+++ b/tests/test_vacuum/test_dps_command_mapping.py
@@ -4,8 +4,8 @@ import pytest
 from unittest.mock import patch, MagicMock
 
 from custom_components.robovac.robovac import RoboVac
-from custom_components.robovac.vacuum import TUYA_CODES, RoboVacEntity
-from custom_components.robovac.vacuums.base import RobovacCommand
+from custom_components.robovac.vacuum import RoboVacEntity
+from custom_components.robovac.vacuums.base import RobovacCommand, TuyaCodes
 from homeassistant.const import (
     CONF_NAME,
     CONF_ID,
@@ -36,17 +36,17 @@ def test_dps_codes_match_expected_values() -> None:
             dps_codes = vacuum.getDpsCodes()
 
             # Verify common DPS values match their respective expected codes
-            assert dps_codes.get("STATUS") == TUYA_CODES.STATUS
-            assert dps_codes.get("BATTERY_LEVEL") == TUYA_CODES.BATTERY_LEVEL
-            assert dps_codes.get("ERROR_CODE") == TUYA_CODES.ERROR_CODE
+            assert dps_codes.get("STATUS") == TuyaCodes.STATUS
+            assert dps_codes.get("BATTERY_LEVEL") == TuyaCodes.BATTERY_LEVEL
+            assert dps_codes.get("ERROR_CODE") == TuyaCodes.ERROR_CODE
 
             # If MODE is in the codes, verify it matches
             if "MODE" in dps_codes:
-                assert dps_codes.get("MODE") == TUYA_CODES.MODE
+                assert dps_codes.get("MODE") == TuyaCodes.MODE
 
             # If FAN_SPEED is in the codes, verify it matches
             if "FAN_SPEED" in dps_codes:
-                assert dps_codes.get("FAN_SPEED") == TUYA_CODES.FAN_SPEED
+                assert dps_codes.get("FAN_SPEED") == TuyaCodes.FAN_SPEED
 
 
 def test_nonstandard_model_dps_codes() -> None:
@@ -64,10 +64,10 @@ def test_nonstandard_model_dps_codes() -> None:
         dps_codes = vacuum.getDpsCodes()
 
         # Verify T2267 has different codes than the defaults
-        assert dps_codes.get("STATUS") != TUYA_CODES.STATUS
-        assert dps_codes.get("BATTERY_LEVEL") != TUYA_CODES.BATTERY_LEVEL
-        assert dps_codes.get("ERROR_CODE") != TUYA_CODES.ERROR_CODE
-        assert dps_codes.get("FAN_SPEED") != TUYA_CODES.FAN_SPEED
+        assert dps_codes.get("STATUS") != TuyaCodes.STATUS
+        assert dps_codes.get("BATTERY_LEVEL") != TuyaCodes.BATTERY_LEVEL
+        assert dps_codes.get("ERROR_CODE") != TuyaCodes.ERROR_CODE
+        assert dps_codes.get("FAN_SPEED") != TuyaCodes.FAN_SPEED
 
 
 def test_getDpsCodes_extraction_method() -> None:
@@ -104,13 +104,13 @@ def test_getDpsCodes_extraction_method() -> None:
         # Verify T2267 has different codes than the defaults
         assert "STATUS" in t2267_dps_codes
         assert t2267_dps_codes["STATUS"] == "153"  # Non-default code
-        assert t2267_dps_codes["STATUS"] != TUYA_CODES.STATUS
+        assert t2267_dps_codes["STATUS"] != TuyaCodes.STATUS
         assert "BATTERY_LEVEL" in t2267_dps_codes
         assert t2267_dps_codes["BATTERY_LEVEL"] == "163"  # Non-default code
-        assert t2267_dps_codes["BATTERY_LEVEL"] != TUYA_CODES.BATTERY_LEVEL
+        assert t2267_dps_codes["BATTERY_LEVEL"] != TuyaCodes.BATTERY_LEVEL
         assert "ERROR_CODE" in t2267_dps_codes
         assert t2267_dps_codes["ERROR_CODE"] == "177"  # Non-default code
-        assert t2267_dps_codes["ERROR_CODE"] != TUYA_CODES.ERROR_CODE
+        assert t2267_dps_codes["ERROR_CODE"] != TuyaCodes.ERROR_CODE
 
         # Test T2320 (another model with non-default codes)
         vacuum_t2320 = RoboVac(
@@ -125,13 +125,13 @@ def test_getDpsCodes_extraction_method() -> None:
         # Verify T2320 has different codes too
         assert "STATUS" in t2320_dps_codes
         assert t2320_dps_codes["STATUS"] == "173"  # Non-default code
-        assert t2320_dps_codes["STATUS"] != TUYA_CODES.STATUS
+        assert t2320_dps_codes["STATUS"] != TuyaCodes.STATUS
         assert "BATTERY_LEVEL" in t2320_dps_codes
         assert t2320_dps_codes["BATTERY_LEVEL"] == "172"  # Non-default code
-        assert t2320_dps_codes["BATTERY_LEVEL"] != TUYA_CODES.BATTERY_LEVEL
+        assert t2320_dps_codes["BATTERY_LEVEL"] != TuyaCodes.BATTERY_LEVEL
         assert "ERROR_CODE" in t2320_dps_codes
         assert t2320_dps_codes["ERROR_CODE"] == "169"  # Non-default code
-        assert t2320_dps_codes["ERROR_CODE"] != TUYA_CODES.ERROR_CODE
+        assert t2320_dps_codes["ERROR_CODE"] != TuyaCodes.ERROR_CODE
 
 
 @pytest.mark.asyncio

--- a/tests/test_vacuum/test_model_dps_analysis.py
+++ b/tests/test_vacuum/test_model_dps_analysis.py
@@ -4,7 +4,7 @@ import pytest
 from unittest.mock import patch
 
 from custom_components.robovac.robovac import RoboVac
-from custom_components.robovac.vacuum import TUYA_CODES
+from custom_components.robovac.vacuums.base import TuyaCodes
 from custom_components.robovac.vacuums import ROBOVAC_MODELS
 
 
@@ -13,18 +13,18 @@ def test_analyze_model_dps_codes() -> None:
     # Dictionary to store results
     model_dps_analysis = {}
 
-    # Default codes from TUYA_CODES
+    # Default codes from TuyaCodes
     default_codes = {
-        "STATUS": TUYA_CODES.STATUS,
-        "BATTERY_LEVEL": TUYA_CODES.BATTERY_LEVEL,
-        "ERROR_CODE": TUYA_CODES.ERROR_CODE,
-        "MODE": TUYA_CODES.MODE,
-        "FAN_SPEED": TUYA_CODES.FAN_SPEED,
-        "CLEANING_AREA": TUYA_CODES.CLEANING_AREA,
-        "CLEANING_TIME": TUYA_CODES.CLEANING_TIME,
-        "AUTO_RETURN": TUYA_CODES.AUTO_RETURN,
-        "DO_NOT_DISTURB": TUYA_CODES.DO_NOT_DISTURB,
-        "BOOST_IQ": TUYA_CODES.BOOST_IQ,
+        "STATUS": TuyaCodes.STATUS,
+        "BATTERY_LEVEL": TuyaCodes.BATTERY_LEVEL,
+        "ERROR_CODE": TuyaCodes.ERROR_CODE,
+        "MODE": TuyaCodes.MODE,
+        "FAN_SPEED": TuyaCodes.FAN_SPEED,
+        "CLEANING_AREA": TuyaCodes.CLEANING_AREA,
+        "CLEANING_TIME": TuyaCodes.CLEANING_TIME,
+        "AUTO_RETURN": TuyaCodes.AUTO_RETURN,
+        "DO_NOT_DISTURB": TuyaCodes.DO_NOT_DISTURB,
+        "BOOST_IQ": TuyaCodes.BOOST_IQ,
     }
 
     # Check each model

--- a/tests/test_vacuum/test_sensor.py
+++ b/tests/test_vacuum/test_sensor.py
@@ -7,7 +7,7 @@ from homeassistant.const import PERCENTAGE, CONF_ID
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 
 from custom_components.robovac.sensor import RobovacBatterySensor
-from custom_components.robovac.vacuum import TUYA_CODES
+from custom_components.robovac.vacuums.base import TuyaCodes
 
 
 @pytest.mark.asyncio
@@ -39,7 +39,7 @@ async def test_battery_sensor_update_success():
 
     # Create mock vacuum entity
     mock_vacuum_entity = MagicMock()
-    mock_vacuum_entity.tuyastatus = {TUYA_CODES.BATTERY_LEVEL: 85}
+    mock_vacuum_entity.tuyastatus = {TuyaCodes.BATTERY_LEVEL: 85}
 
     # Create mock hass data structure
     mock_hass = MagicMock()

--- a/tests/test_vacuum/test_vacuum_entity.py
+++ b/tests/test_vacuum/test_vacuum_entity.py
@@ -4,7 +4,8 @@ import pytest
 from unittest.mock import patch, MagicMock
 
 from homeassistant.components.vacuum import VacuumActivity
-from custom_components.robovac.vacuum import RoboVacEntity, TUYA_CODES
+from custom_components.robovac.vacuum import RoboVacEntity
+from custom_components.robovac.vacuums.base import TuyaCodes
 
 
 @pytest.mark.asyncio
@@ -145,11 +146,11 @@ async def test_update_entity_values(mock_robovac, mock_vacuum_data):
     """Test update_entity_values correctly sets entity attributes."""
     # Arrange
     mock_robovac._dps = {
-        TUYA_CODES.BATTERY_LEVEL: 75,
-        TUYA_CODES.STATUS: "Cleaning",
-        TUYA_CODES.ERROR_CODE: 0,
-        TUYA_CODES.MODE: "auto",
-        TUYA_CODES.FAN_SPEED: "Standard",
+        TuyaCodes.BATTERY_LEVEL: 75,
+        TuyaCodes.STATUS: "Cleaning",
+        TuyaCodes.ERROR_CODE: 0,
+        TuyaCodes.MODE: "auto",
+        TuyaCodes.FAN_SPEED: "Standard",
     }
 
     with patch("custom_components.robovac.vacuum.RoboVac", return_value=mock_robovac):
@@ -182,7 +183,7 @@ async def test_fan_speed_formatting(mock_robovac, mock_vacuum_data):
 
         for input_speed, expected_output in test_cases:
             # Setup
-            mock_robovac._dps = {TUYA_CODES.FAN_SPEED: input_speed}
+            mock_robovac._dps = {TuyaCodes.FAN_SPEED: input_speed}
 
             # Act
             entity.update_entity_values()


### PR DESCRIPTION
Replace all remaining references to the deprecated TUYA_CODES with the new TuyaCodes class
from vacuums.base in test files and sensor modules. This completes the refactoring to ensure
consistent, model-specific DPS code handling across the codebase.

Signed-off-by: Dan Webb <dan.webb@damacus.io>
