### PR TITLE
Home Assistant Devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+{
+  "name": "Example devcontainer for add-on repositories",
+  "image": "ghcr.io/home-assistant/devcontainer:2-addons",
+  "appPort": ["7123:8123", "7357:4357"],
+  "postStartCommand": "bash devcontainer_bootstrap",
+  "runArgs": ["-e", "GIT_EDITOR=code --wait", "--privileged"],
+  "workspaceFolder": "/mnt/supervisor/addons/local/${localWorkspaceFolderBasename}",
+  "workspaceMount": "source=${localWorkspaceFolder},target=${containerWorkspaceFolder},type=bind,consistency=cached",
+  "containerEnv": {
+    "WORKSPACE_DIRECTORY": "${containerWorkspaceFolder}"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": ["timonwong.shellcheck", "esbenp.prettier-vscode"],
+      "settings": {
+        "terminal.integrated.profiles.linux": {
+          "zsh": {
+            "path": "/usr/bin/zsh"
+          }
+        },
+        "terminal.integrated.defaultProfile.linux": "zsh",
+        "editor.formatOnPaste": false,
+        "editor.formatOnSave": true,
+        "editor.formatOnType": true,
+        "files.trimTrailingWhitespace": true
+      }
+    }
+  },
+  "mounts": [
+    "type=volume,target=/var/lib/docker",
+    "type=volume,target=/mnt/supervisor"
+  ]
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,13 +1,14 @@
 {
-  "name": "Example devcontainer for add-on repositories",
+  "name": "Robovac devcontainer",
   "image": "ghcr.io/home-assistant/devcontainer:2-addons",
   "appPort": ["7123:8123", "7357:4357"],
   "postStartCommand": "bash devcontainer_bootstrap",
   "runArgs": ["-e", "GIT_EDITOR=code --wait", "--privileged"],
-  "workspaceFolder": "/mnt/supervisor/addons/local/${localWorkspaceFolderBasename}",
-  "workspaceMount": "source=${localWorkspaceFolder},target=${containerWorkspaceFolder},type=bind,consistency=cached",
   "containerEnv": {
     "WORKSPACE_DIRECTORY": "${containerWorkspaceFolder}"
+  },
+  "features": {
+    "ghcr.io/eitsupi/devcontainer-features/go-task:1": {}
   },
   "customizations": {
     "vscode": {
@@ -28,6 +29,7 @@
   },
   "mounts": [
     "type=volume,target=/var/lib/docker",
-    "type=volume,target=/mnt/supervisor"
+    "type=volume,target=/mnt/supervisor",
+    "source=./custom_components/robovac,target=/mnt/supervisor/homeassistant/custom_components/robovac,type=bind"
   ]
 }

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -38,3 +38,13 @@ tasks:
     desc: Lint with markdownlint
     cmds:
       - markdownlint-cli2 "**/*.md" "!vendor" "!.venv" --fix
+
+  ha-start:
+    desc: Start Home assistant, run from dev container
+    cmds:
+      - supervisor_run
+
+  ha-restart:
+    desc: Restart Home assistant, run from dev container
+    cmds:
+      - ha core restart


### PR DESCRIPTION
Adding the Home Assistant devcontainer from https://developers.home-assistant.io/docs/add-ons/testing/ with additions to taskfile.yaml to start and reload Home Assistant.