### PR TITLE
fix: correct autoReturn toggle logic and mode mappings

### DIFF
--- a/custom_components/robovac/vacuum.py
+++ b/custom_components/robovac/vacuum.py
@@ -852,8 +852,10 @@ class RoboVacEntity(StateVacuumEntity):
             if command_data:
                 await self.vacuum.async_set(command_data)
         elif command == "autoReturn":
+            # Toggle the auto return setting
+            new_value = not self._is_value_true(self.auto_return)
             await self.vacuum.async_set({
-                self._get_dps_code("AUTO_RETURN"): self._is_value_true(self.auto_return)
+                self._get_dps_code("AUTO_RETURN"): new_value
             })
         elif command == "doNotDisturb":
             # Toggle the do not disturb setting

--- a/custom_components/robovac/vacuums/T2275.py
+++ b/custom_components/robovac/vacuums/T2275.py
@@ -22,8 +22,8 @@ class T2275(RobovacModelDetails):
         RobovacCommand.MODE: {
             "code": 152,
             "values": {
-                "small_room": "AggN",
-                "spot": "AA==",
+                "small_room": "AA==",
+                "pause": "AggN",
                 "edge": "AggG",
                 "auto": "BBoCCAE=",
                 "nosweep": "AggO",

--- a/custom_components/robovac/vacuums/T2276.py
+++ b/custom_components/robovac/vacuums/T2276.py
@@ -22,8 +22,8 @@ class T2276(RobovacModelDetails):
         RobovacCommand.MODE: {
             "code": 152,
             "values": {
-                "small_room": "AggN",
-                "spot": "AA==",
+                "small_room": "AA==",
+                "pause": "AggN",
                 "edge": "AggG",
                 "auto": "BBoCCAE=",
                 "nosweep": "AggO",

--- a/custom_components/robovac/vacuums/T2277.py
+++ b/custom_components/robovac/vacuums/T2277.py
@@ -24,8 +24,8 @@ class T2277(RobovacModelDetails):
         RobovacCommand.MODE: {
             "code": 152,
             "values": {
-                "small_room": "AggN",
-                "spot": "AA==",
+                "small_room": "AA==",
+                "pause": "AggN",
                 "edge": "AggG",
                 "auto": "BBoCCAE=",
                 "nosweep": "AggO",

--- a/custom_components/robovac/vacuums/T2278.py
+++ b/custom_components/robovac/vacuums/T2278.py
@@ -23,8 +23,8 @@ class T2278(RobovacModelDetails):
         RobovacCommand.MODE: {
             "code": 152,
             "values": {
-                "small_room": "AggN",
-                "spot": "AA==",
+                "small_room": "AA==",
+                "pause": "AggN",
                 "edge": "AggG",
                 "auto": "BBoCCAE=",
                 "nosweep": "AggO",

--- a/tests/test_vacuum/test_vacuum_commands.py
+++ b/tests/test_vacuum/test_vacuum_commands.py
@@ -181,16 +181,16 @@ async def test_async_send_command(mock_robovac, mock_vacuum_data):
         mock_robovac.async_set.assert_called_once_with({"5": "Auto"})
         mock_robovac.async_set.reset_mock()
 
-        # Test auto return command (when off)
+        # Test auto return command (when off - should toggle to on)
         entity._attr_auto_return = False
         await entity.async_send_command("autoReturn")
-        mock_robovac.async_set.assert_called_once_with({"135": False})
+        mock_robovac.async_set.assert_called_once_with({"135": True})
         mock_robovac.async_set.reset_mock()
 
-        # Test auto return command (when on)
+        # Test auto return command (when on - should toggle to off)
         entity._attr_auto_return = True
         await entity.async_send_command("autoReturn")
-        mock_robovac.async_set.assert_called_once_with({"135": True})
+        mock_robovac.async_set.assert_called_once_with({"135": False})
         mock_robovac.async_set.reset_mock()
 
         # Test do not disturb command (when off - should toggle to on)


### PR DESCRIPTION
- Fix autoReturn command to properly toggle state instead of setting current state
- Correct small_room mode mapping from "AggN" to "AA==" in T2275, T2276, T2277, T2278
- Add proper pause mode mapping for "AggN" value
- Update tests to expect correct toggle behavior

Addresses Copilot AI feedback from PR #149