### PR TITLE
Revert some prior changes to value mappings

### DIFF
--- a/custom_components/robovac/vacuums/T2252.py
+++ b/custom_components/robovac/vacuums/T2252.py
@@ -38,11 +38,11 @@ class T2252(RobovacModelDetails):
         RobovacCommand.MODE: {
             "code": 5,
             "values": {
-                "auto": "Auto",
-                "small_room": "SmallRoom",
-                "spot": "Spot",
-                "edge": "Edge",
-                "nosweep": "Nosweep",
+                "Auto": "Auto",
+                "SmallRoom": "SmallRoom",
+                "Spot": "Spot",
+                "Edge": "Edge",
+                "Nosweep": "Nosweep",
             },
         },
         RobovacCommand.STATUS: {
@@ -54,10 +54,10 @@ class T2252(RobovacModelDetails):
         RobovacCommand.FAN_SPEED: {
             "code": 102,
             "values": {
-                "standard": "Standard",
-                "turbo": "Turbo",
-                "max": "Max",
-                "boost_iq": "Boost_IQ",
+                "Standard": "Standard",
+                "Turbo": "Turbo",
+                "Max": "Max",
+                "Boost_IQ": "Boost_IQ",
             },
         },
         RobovacCommand.LOCATE: {


### PR DESCRIPTION
This is an attempt to solve the issues raised on https://github.com/damacus/robovac/issues/196, and should not be merged without hearing feedback from the owners of that vacuum.

It's based on the fact that comparing 1.3.1 => 1.3.2, I see the following diff, and I'm not sure there's a reason for it given 1.3.1 seems to have been working well:
<img width="2161" height="1309" alt="image" src="https://github.com/user-attachments/assets/8fd3e5dc-5124-4299-b7d7-424155b9e15b" />
