### PR TITLE
Add battery feature, status and error values to T2194 

### DIFF
--- a/custom_components/robovac/vacuums/T2194.py
+++ b/custom_components/robovac/vacuums/T2194.py
@@ -5,7 +5,8 @@ from .base import RoboVacEntityFeature, RobovacCommand, RobovacModelDetails
 
 class T2194(RobovacModelDetails):
     homeassistant_features = (
-        VacuumEntityFeature.CLEAN_SPOT
+        VacuumEntityFeature.BATTERY
+        | VacuumEntityFeature.CLEAN_SPOT
         | VacuumEntityFeature.FAN_SPEED
         | VacuumEntityFeature.LOCATE
         | VacuumEntityFeature.PAUSE
@@ -52,6 +53,12 @@ class T2194(RobovacModelDetails):
         },
         RobovacCommand.STATUS: {
             "code": 15,
+            "values": {
+                "Running": "Running",
+                "Recharge": "Returning to Dock",
+                "standby": "Standby",
+                "Sleeping": "Sleeping",
+            },
         },
         RobovacCommand.RETURN_HOME: {
             "code": 101,
@@ -73,5 +80,8 @@ class T2194(RobovacModelDetails):
         },
         RobovacCommand.ERROR: {
             "code": 106,
+            "values": {
+                "0": "No error",
+            },
         },
     }


### PR DESCRIPTION
## T2194 Update: Add battery feature, status and error values
T2194 = `RoboVac L35 Hybrid (T2194)`

Hello, Dan!
I got a bunch of errors in the debug log, asked Cline to fix them, and here's the result.

### Post-Update Usage Test Results
I haven't tested these results as much as I should, but here's what I've gotten from a couple automatic + spot cleans:
- Battery amount reports correctly
- No-error status is reflected correctly
- Fan speeds Quiet, Standard, Turbo, Max change correctly (but it seems integration doesn't save setting status)
- Docked, Cleaning statuses are reflected correctly
- Unknown value error messages for the four new statuses no longer appear in the log

### Remaining Work
- Log message `Cannot update entity values: no data points available`.
- Most vacuum commands may not work (`Start`, `Pause`, `Spot Cleaning`, `Locate`, `Return to Dock`)
   - `Return to Dock`is the only command that causes my T2194 to light up - it seems it doesn't respond to the other commands
   - `Stop` works IIRC

I'm a bit busy with my wife and newborn, but I will try and help/test where I can!
Thank you!

---
## Commit Description
Features added:
- Battery: added homeassistant_feature
- Status: added values Running, Recharge, standby, Sleeping
- Error-handling: added value 0 "No error"