### PR TITLE
ci: add hassfest validation and fix HACS action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,23 @@ jobs:
     runs-on: ubuntu-latest
     name: runner / hacs
     steps:
-      - uses: hacs/action@d556e736723344f83838d08488c983a15381059a # 22.5.0
+      - name: Check out code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Run HACS validation
+        uses: hacs/action@d556e736723344f83838d08488c983a15381059a # 22.5.0
         with:
           category: integration
+
+  hassfest:
+    runs-on: ubuntu-latest
+    name: runner / hassfest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Run hassfest validation
+        uses: home-assistant/actions/hassfest@master
 
   check-markdown:
     runs-on: ubuntu-latest
@@ -62,7 +76,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     name: runner / test
-    needs: [check-markdown, check-links, lint, hacs]
+    needs: [check-markdown, check-links, lint, hacs, hassfest]
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## Summary
- Add hassfest validation job to validate Home Assistant integration standards
- Fix HACS action by adding missing checkout step so it can access the code
- Add hassfest to test job dependencies to ensure validation runs before tests

## Changes
- **New job**: `hassfest` - Validates Home Assistant integration requirements (manifest, requirements, etc.)
- **Fixed job**: `hacs` - Added checkout step that was missing
- **Updated**: Test job now depends on both HACS and hassfest validation

## References
- [Home Assistant hassfest documentation](https://developers.home-assistant.io/blog/2020/04/16/hassfest/)