### PR TITLE
Fix some models stuck on status "cleaning" when docked and fully charged

### DIFF
--- a/custom_components/robovac/vacuum.py
+++ b/custom_components/robovac/vacuum.py
@@ -285,7 +285,7 @@ class RoboVacEntity(StateVacuumEntity):
                     self._attr_tuya_state
                 )
                 return None
-        elif self._attr_tuya_state == "Charging" or self._attr_tuya_state == "completed":
+        elif self._attr_tuya_state == "Charging" or self._attr_tuya_state == "completed" or self._attr_tuya_state == "Completed":
             return VacuumActivity.DOCKED
         elif self._attr_tuya_state == "Recharge":
             return VacuumActivity.RETURNING


### PR DESCRIPTION
## Description
Fixes issue #342 
This PR addresses an issue in `custom_components/robovac/vacuum.py` where the vacuum state was not being correctly reported/updated in Home Assistant.
Some models seem to report status as `Completed`, note capitalized "C", once charging status reaches 100%
As verified in a debug log:
```
2026-02-13 14:34:13.004 DEBUG (MainThread) [custom_components.robovac.vacuum] in _update_state_and_error, tuya_state: completed, self._attr_tuya_state: Completed.
```

## Changes
- Modified `vacuum.py` to ensure consistent state reporting.

## Testing
- Tested locally with my Eufy RoboVac.
- Verified that the entity status now correctly reflects the physical device state in the Home Assistant UI.
- Reports of same behavior seen in issue thread [https://github.com/damacus/robovac/issues/342#issuecomment-3905009958](url), with this change fixing it. 

