### PR TITLE
fix(sensor): resolve lint and type errors in battery sensor

### DIFF
--- a/custom_components/robovac/sensor.py
+++ b/custom_components/robovac/sensor.py
@@ -94,14 +94,23 @@ class RobovacBatterySensor(SensorEntity):
             battery_value = vacuum_entity.tuyastatus.get(battery_dps_code)
 
             if battery_value is not None:
-                self._attr_native_value = battery_value
-                self._attr_available = True
-                _LOGGER.debug(
-                    "Battery for %s: %s%% (DPS code: %s)",
-                    self.robovac_id,
-                    battery_value,
-                    battery_dps_code
-                )
+                try:
+                    self._attr_native_value = int(battery_value)
+                    self._attr_available = True
+                    _LOGGER.debug(
+                        "Battery for %s: %s%% (DPS code: %s)",
+                        self.robovac_id,
+                        self._attr_native_value,
+                        battery_dps_code
+                    )
+                except (ValueError, TypeError) as ex:
+                    _LOGGER.error(
+                        "Invalid battery value %s for %s: %s",
+                        battery_value,
+                        self.robovac_id,
+                        ex
+                    )
+                    self._attr_available = False
             else:
                 _LOGGER.debug(
                     "Battery DPS code %s not in tuyastatus. Available codes: %s",


### PR DESCRIPTION
This PR is a revised version of #352, resolving all lint and type-check errors.

### Changes
- Replaced hardcoded battery DPS code with dynamic lookup using getDpsCodes().
- Properly typed vacuum_entity using TYPE_CHECKING to avoid circular imports.
- Ensured battery_value is cast to an integer for Home Assistant compatibility.
- Fixed whitespace and newline lint issues.

**Credit:** Original implementation by @MixamTheGreat.