### PR TITLE
🎨 Palette: Improve config flow descriptions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-24 - Helper text in Config Flows
+**Learning:** Home Assistant configuration flows support inline field helper text by adding a `data_description` object containing keys that map to the `data` schema keys within `strings.json` and translation files.
+**Action:** Use `data_description` rather than relying solely on the step `description` to provide specific, field-level guidance in Home Assistant integrations.

--- a/custom_components/robovac/strings.json
+++ b/custom_components/robovac/strings.json
@@ -33,6 +33,9 @@
                     "autodiscovery": "Enable autodiscovery",
                     "ip_address": "IP Address"
                 },
+                "data_description": {
+                    "ip_address": "Leave blank if autodiscovery is enabled. Otherwise, enter the static IP address of your vacuum."
+                },
                 "description": "Autodiscovery will automatically update the IP address"
             }
         }

--- a/custom_components/robovac/translations/en.json
+++ b/custom_components/robovac/translations/en.json
@@ -33,6 +33,9 @@
                     "autodiscovery": "Enable autodiscovery",
                     "ip_address": "IP Address"
                 },
+                "data_description": {
+                    "ip_address": "Leave blank if autodiscovery is enabled. Otherwise, enter the static IP address of your vacuum."
+                },
                 "description": "Autodiscovery will automatically update the IP address"
             }
         }

--- a/uv.lock
+++ b/uv.lock
@@ -4,5 +4,5 @@ requires-python = ">=3.13.0"
 
 [[package]]
 name = "robovac"
-version = "2.2.0b1"
+version = "2.2.1b1"
 source = { editable = "." }


### PR DESCRIPTION
💡 **What:** 
Added a `data_description` object for the `ip_address` field in the `options.step.edit` config flow in both `strings.json` and `translations/en.json`.

🎯 **Why:** 
Previously, the options flow only had a general step description explaining that autodiscovery automatically updates the IP address. By adding an inline helper text directly to the `ip_address` field ("Leave blank if autodiscovery is enabled. Otherwise, enter the static IP address of your vacuum."), it provides clearer context at the point of interaction, reducing user confusion when they edit their vacuum settings.

📸 **Before/After:**
- *Before*: The `IP Address` field appeared without specific guidance attached to it, relying on the user reading the step description above.
- *After*: The `IP Address` field now features descriptive text directly beneath it, clarifying its conditional usage based on the `autodiscovery` toggle.

♿ **Accessibility / Usability:**
Improves cognitive accessibility by providing clear, actionable helper text directly associated with a complex conditional form field. Users no longer have to guess when the field is required or optional.

---
*PR created automatically by Jules for task [8798162751919321671](https://jules.google.com/task/8798162751919321671) started by @damacus*