### PR TITLE
🎨 Palette: Add config flow helper text translations

### DIFF
--- a/custom_components/robovac/translations/cy.json
+++ b/custom_components/robovac/translations/cy.json
@@ -15,6 +15,10 @@
                     "password": "Cyfrinair",
                     "username": "Enw defnyddiwr"
                 },
+                "data_description": {
+                    "username": "Y cyfeiriad e-bost sy'n gysylltiedig â'ch cyfrif Eufy.",
+                    "password": "Y cyfrinair a ddefnyddir i fewngofnodi i'r app Eufy."
+                },
                 "description": "Rhowch fanylion eich cyfrif Eufy"
             }
         }
@@ -32,6 +36,10 @@
                 "data": {
                     "autodiscovery": "Galluogi awto-ddarganfod",
                     "ip_address": "Cyfeiriad IP"
+                },
+                "data_description": {
+                    "autodiscovery": "Dod o hyd i'r sugnwr llwch yn awtomatig ar y rhwydwaith.",
+                    "ip_address": "Cyfeiriad IP statig eich sugnwr llwch ar eich rhwydwaith lleol (dewisol os yw awto-ddarganfod wedi'i alluogi)."
                 },
                 "description": "Bydd awto-ddarganfod yn diweddaru'r cyfeiriad IP yn awtomatig"
             }

--- a/custom_components/robovac/translations/de.json
+++ b/custom_components/robovac/translations/de.json
@@ -15,6 +15,10 @@
                     "password": "Passwort",
                     "username": "Benutzername"
                 },
+                "data_description": {
+                    "username": "Die mit Ihrem Eufy-Konto verknüpfte E-Mail-Adresse.",
+                    "password": "Das Passwort, mit dem Sie sich in der Eufy-App anmelden."
+                },
                 "description": "Geben Sie Ihre Eufy-Kontodaten ein"
             }
         }
@@ -32,6 +36,10 @@
                 "data": {
                     "autodiscovery": "Autodiscovery aktivieren",
                     "ip_address": "IP-Adresse"
+                },
+                "data_description": {
+                    "autodiscovery": "Den Staubsauger automatisch im Netzwerk finden.",
+                    "ip_address": "Die statische IP-Adresse Ihres Staubsaugers in Ihrem lokalen Netzwerk (optional, wenn Autodiscovery aktiviert ist)."
                 },
                 "description": "Autodiscovery aktualisiert die IP-Adresse automatisch"
             }

--- a/custom_components/robovac/translations/es.json
+++ b/custom_components/robovac/translations/es.json
@@ -15,6 +15,10 @@
                     "password": "Contraseña",
                     "username": "Nombre de usuario"
                 },
+                "data_description": {
+                    "username": "La dirección de correo electrónico asociada a tu cuenta Eufy.",
+                    "password": "La contraseña utilizada para iniciar sesión en la aplicación Eufy."
+                },
                 "description": "Ingrese los detalles de su cuenta Eufy"
             }
         }
@@ -32,6 +36,10 @@
                 "data": {
                     "autodiscovery": "Habilitar autodescubrimiento",
                     "ip_address": "Dirección IP"
+                },
+                "data_description": {
+                    "autodiscovery": "Encontrar automáticamente la aspiradora en la red.",
+                    "ip_address": "La dirección IP estática de su aspiradora en su red local (opcional si el autodescubrimiento está habilitado)."
                 },
                 "description": "El autodescubrimiento actualizará automáticamente la dirección IP"
             }

--- a/custom_components/robovac/translations/fr.json
+++ b/custom_components/robovac/translations/fr.json
@@ -15,6 +15,10 @@
                     "password": "Mot de passe",
                     "username": "Nom d'utilisateur"
                 },
+                "data_description": {
+                    "username": "L'adresse e-mail associée à votre compte Eufy.",
+                    "password": "Le mot de passe utilisé pour vous connecter à l'application Eufy."
+                },
                 "description": "Entrez les détails de votre compte Eufy"
             }
         }
@@ -32,6 +36,10 @@
                 "data": {
                     "autodiscovery": "Activer la découverte automatique",
                     "ip_address": "Adresse IP"
+                },
+                "data_description": {
+                    "autodiscovery": "Trouver automatiquement l'aspirateur sur le réseau.",
+                    "ip_address": "L'adresse IP statique de votre aspirateur sur votre réseau local (optionnel si la découverte automatique est activée)."
                 },
                 "description": "La découverte automatique mettra à jour automatiquement l'adresse IP"
             }

--- a/custom_components/robovac/translations/it.json
+++ b/custom_components/robovac/translations/it.json
@@ -15,6 +15,10 @@
                     "password": "Password",
                     "username": "Nome utente"
                 },
+                "data_description": {
+                    "username": "L'indirizzo email associato al tuo account Eufy.",
+                    "password": "La password utilizzata per accedere all'app Eufy."
+                },
                 "description": "Inserisci i dettagli del tuo account Eufy"
             }
         }
@@ -32,6 +36,10 @@
                 "data": {
                     "autodiscovery": "Abilita rilevamento automatico",
                     "ip_address": "Indirizzo IP"
+                },
+                "data_description": {
+                    "autodiscovery": "Trova automaticamente l'aspirapolvere sulla rete.",
+                    "ip_address": "L'indirizzo IP statico del tuo aspirapolvere sulla tua rete locale (opzionale se il rilevamento automatico è abilitato)."
                 },
                 "description": "Il rilevamento automatico aggiornerà automaticamente l'indirizzo IP"
             }

--- a/custom_components/robovac/translations/nl.json
+++ b/custom_components/robovac/translations/nl.json
@@ -15,6 +15,10 @@
                     "password": "Wachtwoord",
                     "username": "Gebruikersnaam"
                 },
+                "data_description": {
+                    "username": "Het e-mailadres dat is gekoppeld aan uw Eufy-account.",
+                    "password": "Het wachtwoord dat is gebruikt om in te loggen op de Eufy-app."
+                },
                 "description": "Voer uw Eufy-accountgegevens in"
             }
         }
@@ -32,6 +36,10 @@
                 "data": {
                     "autodiscovery": "Automatische detectie inschakelen",
                     "ip_address": "IP-adres"
+                },
+                "data_description": {
+                    "autodiscovery": "Vind de stofzuiger automatisch op het netwerk.",
+                    "ip_address": "Het statische IP-adres van uw stofzuiger op uw lokale netwerk (optioneel als automatische detectie is ingeschakeld)."
                 },
                 "description": "Automatische detectie zal het IP-adres automatisch bijwerken"
             }

--- a/custom_components/robovac/translations/pt.json
+++ b/custom_components/robovac/translations/pt.json
@@ -15,6 +15,10 @@
                     "password": "Senha",
                     "username": "Nome de usuário"
                 },
+                "data_description": {
+                    "username": "O endereço de e-mail associado à sua conta Eufy.",
+                    "password": "A senha usada para fazer login no aplicativo Eufy."
+                },
                 "description": "Insira os detalhes da sua conta Eufy"
             }
         }
@@ -32,6 +36,10 @@
                 "data": {
                     "autodiscovery": "Ativar descoberta automática",
                     "ip_address": "Endereço IP"
+                },
+                "data_description": {
+                    "autodiscovery": "Encontrar automaticamente o aspirador na rede.",
+                    "ip_address": "O endereço IP estático do seu aspirador na sua rede local (opcional se a descoberta automática estiver ativada)."
                 },
                 "description": "A descoberta automática atualizará automaticamente o endereço IP"
             }


### PR DESCRIPTION
**💡 What**: Added `data_description` to the configuration and options flow steps in `fr.json`, `es.json`, `de.json`, `it.json`, `nl.json`, `pt.json`, and `cy.json`.
**🎯 Why**: To translate the inline helper text for configuration flow fields into various languages, ensuring consistency with `strings.json` and `en.json`.
**📸 Before/After**: N/A (Non-visual backend change, though it renders helper text in the Home Assistant UI)
**♿ Accessibility**: Improves cognitive accessibility by providing context-specific instructions directly below form inputs, ensuring users fully understand what information is required before proceeding.

---
*PR created automatically by Jules for task [3222745025037884863](https://jules.google.com/task/3222745025037884863) started by @damacus*