### PR TITLE
🛡️ Sentinel: [HIGH] Fix global state mutation and missing timeouts in Eufy API requests

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-14 - Global State Mutation & Incomplete Exception Handling in Requests
+**Vulnerability:** Global HTTP headers dictionary mutated per request (`eufyheaders["token"] = token`); `requests` calls lacked proper timeouts or only caught `ConnectionError`.
+**Learning:** Mutating global dictionaries creates race conditions and cross-session data leakage in long-running Home Assistant integrations. Not catching `requests.exceptions.RequestException` (or `Timeout`) when adding timeouts leaves unhandled exceptions that can crash integrations or expose internal states.
+**Prevention:** Always create a local copy of global configuration objects (e.g., `headers = eufyheaders.copy()`) before modifying them for a request. Always enforce a timeout on external API requests (e.g., `timeout=10`) to mitigate DoS risks, and always use `requests.exceptions.RequestException` to comprehensively catch network and timeout failures securely.

--- a/custom_components/robovac/eufywebapi.py
+++ b/custom_components/robovac/eufywebapi.py
@@ -48,8 +48,8 @@ class EufyLogon:
         }
 
         try:
-            return requests.post(login_url, json=login_auth, headers=eufyheaders)
-        except requests.exceptions.ConnectionError:
+            return requests.post(login_url, json=login_auth, headers=eufyheaders, timeout=10)
+        except requests.exceptions.RequestException:
             return None
 
     def get_user_settings(
@@ -66,13 +66,14 @@ class EufyLogon:
             Response object or None if connection error occurs.
         """
         setting_url = url + "/v1/user/setting"
-        eufyheaders["token"] = token
-        eufyheaders["id"] = userid
+        headers = eufyheaders.copy()
+        headers["token"] = token
+        headers["id"] = userid
         try:
             return requests.request(
-                "GET", setting_url, headers=eufyheaders, timeout=1.5
+                "GET", setting_url, headers=headers, timeout=1.5
             )
-        except requests.exceptions.ConnectionError:
+        except requests.exceptions.RequestException:
             return None
 
     def get_device_info(
@@ -89,9 +90,10 @@ class EufyLogon:
             Response object or None if connection error occurs.
         """
         device_url = url + "/v1/device/v2"
-        eufyheaders["token"] = token
-        eufyheaders["id"] = userid
+        headers = eufyheaders.copy()
+        headers["token"] = token
+        headers["id"] = userid
         try:
-            return requests.request("GET", device_url, headers=eufyheaders)
-        except requests.exceptions.ConnectionError:
+            return requests.request("GET", device_url, headers=headers, timeout=10)
+        except requests.exceptions.RequestException:
             return None


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Global HTTP header mutation leading to race conditions & potential cross-session token leakage; missing request timeouts (DoS risk) and incomplete exception handling when network errors occur.
🎯 Impact: In concurrent environments, mutating a global `eufyheaders` dictionary per-request means the `token` and `id` for one user could be injected into a request made simultaneously by another user. Without timeouts, the integration could hang indefinitely. If exceptions other than `ConnectionError` (like `Timeout`) are thrown, they crash the integration and leave unhandled exceptions in the logs.
🔧 Fix: 
1. `eufywebapi.py` now uses local shallow copies of `eufyheaders` (`headers = eufyheaders.copy()`) before applying user-specific tokens.
2. Appended `timeout=10` to `requests.post()` and `requests.request()` calls where it was missing.
3. Expanded `except requests.exceptions.ConnectionError:` to `except requests.exceptions.RequestException:` to safely catch all requests-related exceptions and return `None` as intended.
✅ Verification: Ran `pytest` suite and `flake8` linters locally to confirm behavior changes did not introduce regressions.

Added a critical learning to `.jules/sentinel.md` noting the vulnerability.

---
*PR created automatically by Jules for task [2402545372248043967](https://jules.google.com/task/2402545372248043967) started by @damacus*