### PR TITLE
⚡ Bolt: Optimize VacuumActivity value checking in property getter

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -3,3 +3,7 @@
 ## 2026-03-03 - [Python CRC32 Optimization]
 **Learning:** Pure Python iterative implementations of standard algorithms like CRC32 are extremely slow and add overhead to network protocol processing (Tuya protocol).
 **Action:** Always replace pure Python byte-iteration loops with standard library C-extensions (like `zlib.crc32`) when available for significant performance gains.
+
+## 2026-03-03 - [Property Getter Optimization]
+**Learning:** Property getters in Home Assistant are called extremely frequently on every read/update cycle. Placing inline list comprehensions (like `[activity.value for activity in VacuumActivity]`) inside these getters creates unnecessary O(n) overhead on every access.
+**Action:** Pre-calculate static lists/sets into module-level constants (e.g., `VACUUM_ACTIVITY_VALUES = {activity.value for activity in VacuumActivity}`) to ensure property access remains O(1) and garbage collection overhead is minimized.

--- a/custom_components/robovac/vacuum.py
+++ b/custom_components/robovac/vacuum.py
@@ -72,6 +72,10 @@ _LOGGER = logging.getLogger(__name__)
 SCAN_INTERVAL = timedelta(seconds=REFRESH_RATE)
 UPDATE_RETRIES = 3
 
+# ⚡ Bolt optimization: Pre-calculate valid VacuumActivity values into a set
+# to avoid O(n) list comprehension on every property getter access
+VACUUM_ACTIVITY_VALUES = {activity.value for activity in VacuumActivity}
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -264,7 +268,7 @@ class RoboVacEntity(StateVacuumEntity):
                 )
             )
             return VacuumActivity.ERROR
-        elif self._attr_tuya_state in [activity.value for activity in VacuumActivity]:
+        elif self._attr_tuya_state in VACUUM_ACTIVITY_VALUES:
             # Particularly at system startup, the state may be set to a
             # VacuumActivity value directly, so we can return it as is.
             return cast(VacuumActivity, self._attr_tuya_state)


### PR DESCRIPTION
**💡 What:** 
Pre-calculated the valid `VacuumActivity` values into a module-level constant set (`VACUUM_ACTIVITY_VALUES`) and updated the `activity` property to check against this set.

**🎯 Why:** 
In Home Assistant, property getters like `activity` are called extremely frequently (during state machine updates, template rendering, and frontend polling). The original implementation used an inline list comprehension `[activity.value for activity in VacuumActivity]` within the getter, triggering an $O(n)$ iteration, memory allocation for a new list, and an $O(n)$ linear search every single time it was read. 

**📊 Impact:** 
Reduces the overhead of accessing the `activity` property from $O(n)$ list creation and search to an $O(1)$ set lookup, completely removing repeated memory allocation and garbage collection overhead on a critical hot path.

**🔬 Measurement:** 
Run profiling on property getter access times or observe reduction in garbage collection cycles during high-frequency polling. Tests confirm functionality is fully preserved.

---
*PR created automatically by Jules for task [12665320377093454011](https://jules.google.com/task/12665320377093454011) started by @damacus*