### PR TITLE
🎨 Palette: [Add helpful data_description to selected_vacuum in options flow]

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,6 +1,3 @@
-## 2024-05-18 - Home Assistant Config Flow Form Fields Helper Text
-**Learning:** Home Assistant supports providing inline helper text directly beneath the configuration and options flow form fields using the `data_description` object within `strings.json` and `translations/*.json`.
-**Action:** Use this to provide better descriptions of the fields rather than putting the explanation in the description box on top.
-## 2024-03-24 - Helper text in Config Flows
-**Learning:** Home Assistant configuration flows support inline field helper text by adding a `data_description` object containing keys that map to the `data` schema keys within `strings.json` and translation files.
-**Action:** Use `data_description` rather than relying solely on the step `description` to provide specific, field-level guidance in Home Assistant integrations.
+## 2024-05-19 - Improved configuration options flow clarity
+**Learning:** Found that options flow fields like 'selected_vacuum' lack description data in some Home Assistant integrations, which can confuse users. Adding a 'data_description' element to 'strings.json' (and translation files) provides helpful inline helper text that makes the configuration process much more accessible and intuitive.
+**Action:** Always check `strings.json` and `translations/*.json` for missing `data_description` helpers on configuration and options flow fields, especially for lists or abstract selections like `selected_vacuum`.

--- a/custom_components/robovac/strings.json
+++ b/custom_components/robovac/strings.json
@@ -29,6 +29,9 @@
                 "title": "Manage vacuums",
                 "data": {
                     "selected_vacuum": "Select the Vacuum to edit"
+                },
+                "data_description": {
+                    "selected_vacuum": "Choose the Eufy RoboVac device you wish to configure from the list of discovered vacuums."
                 }
             },
             "edit": {

--- a/custom_components/robovac/translations/cy.json
+++ b/custom_components/robovac/translations/cy.json
@@ -29,6 +29,9 @@
                 "title": "Rheoli sugnwyr llwch",
                 "data": {
                     "selected_vacuum": "Dewiswch y sugnwr llwch i'w olygu"
+                },
+                "data_description": {
+                    "selected_vacuum": "Dewiswch y ddyfais Eufy RoboVac rydych chi am ei ffurfweddu o'r rhestr o sugnwyr llwch a ddarganfuwyd."
                 }
             },
             "edit": {

--- a/custom_components/robovac/translations/de.json
+++ b/custom_components/robovac/translations/de.json
@@ -29,6 +29,9 @@
                 "title": "Staubsauger verwalten",
                 "data": {
                     "selected_vacuum": "Wählen Sie den zu bearbeitenden Staubsauger aus"
+                },
+                "data_description": {
+                    "selected_vacuum": "Wählen Sie das Eufy RoboVac-Gerät, das Sie konfigurieren möchten, aus der Liste der erkannten Staubsauger."
                 }
             },
             "edit": {

--- a/custom_components/robovac/translations/en.json
+++ b/custom_components/robovac/translations/en.json
@@ -29,6 +29,9 @@
                 "title": "Manage vacuums",
                 "data": {
                     "selected_vacuum": "Select the Vacuum to edit"
+                },
+                "data_description": {
+                    "selected_vacuum": "Choose the Eufy RoboVac device you wish to configure from the list of discovered vacuums."
                 }
             },
             "edit": {

--- a/custom_components/robovac/translations/es.json
+++ b/custom_components/robovac/translations/es.json
@@ -29,6 +29,9 @@
                 "title": "Gestionar aspiradoras",
                 "data": {
                     "selected_vacuum": "Seleccione la aspiradora a editar"
+                },
+                "data_description": {
+                    "selected_vacuum": "Elija el dispositivo Eufy RoboVac que desea configurar en la lista de aspiradoras descubiertas."
                 }
             },
             "edit": {

--- a/custom_components/robovac/translations/fr.json
+++ b/custom_components/robovac/translations/fr.json
@@ -29,6 +29,9 @@
                 "title": "Gérer les aspirateurs",
                 "data": {
                     "selected_vacuum": "Sélectionnez l'aspirateur à modifier"
+                },
+                "data_description": {
+                    "selected_vacuum": "Choisissez l'aspirateur Eufy RoboVac que vous souhaitez configurer dans la liste des aspirateurs découverts."
                 }
             },
             "edit": {

--- a/custom_components/robovac/translations/it.json
+++ b/custom_components/robovac/translations/it.json
@@ -29,6 +29,9 @@
                 "title": "Gestisci aspirapolvere",
                 "data": {
                     "selected_vacuum": "Seleziona l'aspirapolvere da modificare"
+                },
+                "data_description": {
+                    "selected_vacuum": "Scegli il dispositivo Eufy RoboVac che desideri configurare dall'elenco degli aspirapolvere rilevati."
                 }
             },
             "edit": {

--- a/custom_components/robovac/translations/nl.json
+++ b/custom_components/robovac/translations/nl.json
@@ -29,6 +29,9 @@
                 "title": "Stofzuigers beheren",
                 "data": {
                     "selected_vacuum": "Selecteer de te bewerken stofzuiger"
+                },
+                "data_description": {
+                    "selected_vacuum": "Kies het Eufy RoboVac-apparaat dat u wilt configureren uit de lijst met ontdekte stofzuigers."
                 }
             },
             "edit": {

--- a/custom_components/robovac/translations/pt.json
+++ b/custom_components/robovac/translations/pt.json
@@ -29,6 +29,9 @@
                 "title": "Gerenciar aspiradores",
                 "data": {
                     "selected_vacuum": "Selecione o aspirador para editar"
+                },
+                "data_description": {
+                    "selected_vacuum": "Escolha o dispositivo Eufy RoboVac que deseja configurar na lista de aspiradores descobertos."
                 }
             },
             "edit": {


### PR DESCRIPTION
💡 What: Added `data_description` fields to the `options.step.init` section within `strings.json` and all translation files to provide context to the `selected_vacuum` form field.

🎯 Why: To clarify to the user what to select in the options flow since selecting a vacuum ID or internal name directly could be non-intuitive. Inline helper texts help make configuration clearer.

📸 Before/After: N/A - text-based configuration flow improvement.

♿ Accessibility: Better context to form fields, assisting screen readers and users who require clear labeling and instructions.

---
*PR created automatically by Jules for task [14768637584223565098](https://jules.google.com/task/14768637584223565098) started by @damacus*