### PR TITLE
🛡️ Sentinel: [MEDIUM] Add missing timeout to Tuya web API POST request

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Global `eufyheaders` dictionary was being mutated with user-specific `token` and `id` during Eufy API requests.
 **Learning:** In Home Assistant integrations where multiple instances or concurrent requests may occur, mutating global module-level dictionaries causes sensitive user data (tokens/IDs) to leak across sessions.
 **Prevention:** Always create a local copy (`headers = global_headers.copy()`) before adding user-specific or sensitive request headers.
+
+## 2025-03-06 - Missing timeouts on Tuya API requests
+**Vulnerability:** External HTTP requests to Tuya Web API using `requests.Session.post` lacked a explicit `timeout` configuration.
+**Learning:** Missing timeout parameters on external network requests can lead to thread exhaustion and DoS if the external server hangs, especially critical in a Home Assistant integration.
+**Prevention:** Always add a `timeout=` parameter to `requests` calls (e.g. `timeout=10`).

--- a/custom_components/robovac/tuyawebapi.py
+++ b/custom_components/robovac/tuyawebapi.py
@@ -269,6 +269,7 @@ class TuyaAPISession:
                     "sign": self.get_signature(query_params, encoded_post_data),
                 },
                 data={"postData": encoded_post_data} if encoded_post_data else None,
+                timeout=10,
             )
             resp.raise_for_status()
             response_data: Dict[str, Any] = resp.json()


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Uncontrolled Resource Consumption (CWE-400). The `self.session.post` call in `custom_components/robovac/tuyawebapi.py` did not configure a `timeout` argument.
🎯 **Impact:** If the Tuya server hangs or is slow, the Home Assistant integration's thread would be blocked indefinitely, leading to resource exhaustion or preventing other Home Assistant operations.
🔧 **Fix:** Added a `timeout=10` parameter to the `self.session.post` call inside the `_request` function. `requests.RequestException` was already being caught, so no additional exception handling was needed.
✅ **Verification:** Verified by running tests via `pytest` and checking linter output via `flake8`. Added entry to `.jules/sentinel.md` journal.

---
*PR created automatically by Jules for task [5942028273339541296](https://jules.google.com/task/5942028273339541296) started by @damacus*