### PR TITLE
🧹 remove unused typing imports in vacuums/base.py

### DIFF
--- a/custom_components/robovac/vacuums/base.py
+++ b/custom_components/robovac/vacuums/base.py
@@ -1,6 +1,6 @@
 from homeassistant.components.vacuum import VacuumActivity
 from enum import IntEnum, StrEnum
-from typing import Protocol, Dict, List, Any, Type, Optional
+from typing import Any, Dict, Protocol
 
 
 class RoboVacEntityFeature(IntEnum):


### PR DESCRIPTION
🎯 **What:** Removed unused `typing` imports (`List`, `Type`, `Optional`) from `custom_components/robovac/vacuums/base.py`.
💡 **Why:** Cleaning up unused imports improves code maintainability and readability by reducing noise.
✅ **Verification:** Verified by manual inspection and `python3 -m py_compile` to ensure no syntax errors. Note that full test suite execution was limited by the environment but the change is purely type-hinting related.
✨ **Result:** A cleaner and more concise import block in `base.py`.

---
*PR created automatically by Jules for task [5082447144487036189](https://jules.google.com/task/5082447144487036189) started by @damacus*