### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix weak random number generation for device IDs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** `ast.literal_eval` was used to parse base64-encoded consumables data from Tuya devices.
 **Learning:** While safer than `eval()`, `ast.literal_eval` on untrusted external data can still be risky (e.g., DoS via complex structures) and is not the standard way to handle JSON data.
 **Prevention:** Use `json.loads` for parsing JSON data from external sources and ensure appropriate type checking (e.g., `isinstance(data, dict)`) before accessing keys.
+
+## 2025-03-08 - Weak random number generation for security-sensitive operations
+**Vulnerability:** The standard library `random` module, which relies on a predictable pseudo-random number generator, was used to generate API device IDs.
+**Learning:** Predictable PRNGs can allow attackers to guess device IDs or session tokens, potentially bypassing authentication or rate-limiting mechanisms.
+**Prevention:** Always use the `secrets` module (which relies on `os.urandom`) for generating secure random numbers for passwords, account authentication, security tokens, and related secrets.

--- a/custom_components/robovac/tuyawebapi.py
+++ b/custom_components/robovac/tuyawebapi.py
@@ -14,7 +14,7 @@ from hashlib import md5, sha256
 import hmac
 import json
 import math
-import random
+import secrets
 import string
 import time
 import uuid
@@ -177,7 +177,7 @@ class TuyaAPISession:
         base64_characters = string.ascii_letters + string.digits
         device_id_dependent_part = "8534c8ec0ed0"
         return device_id_dependent_part + "".join(
-            random.choice(base64_characters)
+            secrets.choice(base64_characters)
             for _ in range(expected_length - len(device_id_dependent_part))
         )
 


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The standard library `random` module, which relies on a predictable pseudo-random number generator, was used to generate Tuya API device IDs in `custom_components/robovac/tuyawebapi.py`.
🎯 **Impact:** Predictable PRNGs can allow attackers to guess device IDs, potentially bypassing authentication, authorization, or rate-limiting mechanisms on the Tuya cloud API.
🔧 **Fix:** Replaced `random.choice` with `secrets.choice` to use a cryptographically strong PRNG (`os.urandom`) for secure device ID generation. Added a journal entry to `.jules/sentinel.md` documenting the learning.
✅ **Verification:** Ran `uv run pytest tests/` and verified that all tests passed successfully, confirming no regressions. Tested that the device ID generation still produces standard base64 strings of the expected length.

---
*PR created automatically by Jules for task [6065751105920486578](https://jules.google.com/task/6065751105920486578) started by @damacus*