### PR TITLE
Draft: Alternative DPS 152 roomClean support

### DIFF
--- a/custom_components/robovac/vacuum.py
+++ b/custom_components/robovac/vacuum.py
@@ -76,6 +76,34 @@ UPDATE_RETRIES = 3
 VACUUM_ACTIVITY_VALUES = {activity.value for activity in VacuumActivity}
 
 
+def _build_protobuf_room_clean(
+    room_ids: list[int], clean_times: int = 1, map_id: int = 1
+) -> str:
+    """Build a base64-encoded protobuf SelectRoomsClean command."""
+
+    def vi(n: int) -> bytes:
+        result: list[int] = []
+        while True:
+            result.append(n & 0x7F)
+            n >>= 7
+            if not n:
+                break
+        for i in range(len(result) - 1):
+            result[i] |= 0x80
+        return bytes(result)
+
+    def lf(field_number: int, data: bytes) -> bytes:
+        return vi((field_number << 3) | 2) + vi(len(data)) + data
+
+    def vf(field_number: int, value: int) -> bytes:
+        return vi(field_number << 3) + vi(value)
+
+    rooms = b"".join(lf(1, vf(1, room_id) + vf(2, 1)) for room_id in room_ids)
+    select = rooms + vf(2, clean_times) + vf(3, map_id)
+    request = vf(1, 1) + lf(4, select)
+    return base64.b64encode(vi(len(request)) + request).decode()
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -929,24 +957,37 @@ class RoboVacEntity(StateVacuumEntity):
             await self.vacuum.async_set({
                 self.get_dps_code("BOOST_IQ"): new_value
             })
-        elif command in ("roomClean", "room_clean") and params is not None and isinstance(params, dict):
+        elif (
+            command in ("roomClean", "room_clean")
+            and params is not None
+            and isinstance(params, dict)
+        ):
             room_ids = params.get("roomIds") or params.get("room_ids", [1])
             count = params.get("count", 1)
-            clean_request = {"roomIds": room_ids, "cleanTimes": count}
-            method_call = {
-                "method": "selectRoomsClean",
-                "data": clean_request,
-                "timestamp": round(time.time() * 1000),
-            }
-            json_str = json.dumps(method_call, separators=(",", ":"))
-            base64_str = base64.b64encode(json_str.encode("utf8")).decode("utf8")
-            _LOGGER.debug("roomClean call %s", json_str)
-            await self.vacuum.async_set({TuyaCodes.ROOM_CLEAN: base64_str})
-            # Wait for the vacuum to ACK DPS 124 before sending the start command.
-            # Without this delay, DPS 2 arrives before the room selection is processed
-            # and the vacuum ignores the start command.
-            await asyncio.sleep(1)
-            await self.vacuum.async_set({TuyaCodes.START_PAUSE: True})
+            if not isinstance(room_ids, list):
+                room_ids = [room_ids]
+
+            if self.get_dps_code("MODE") == "152":
+                map_id = params.get("mapId") or params.get("map_id", 1)
+                payload = _build_protobuf_room_clean(room_ids, count, map_id)
+                _LOGGER.debug("roomClean protobuf rooms=%s map=%s", room_ids, map_id)
+                await self.vacuum.async_set({self.get_dps_code("MODE"): payload})
+            else:
+                clean_request = {"roomIds": room_ids, "cleanTimes": count}
+                method_call = {
+                    "method": "selectRoomsClean",
+                    "data": clean_request,
+                    "timestamp": round(time.time() * 1000),
+                }
+                json_str = json.dumps(method_call, separators=(",", ":"))
+                base64_str = base64.b64encode(json_str.encode("utf8")).decode("utf8")
+                _LOGGER.debug("roomClean call %s", json_str)
+                await self.vacuum.async_set({TuyaCodes.ROOM_CLEAN: base64_str})
+                # Wait for the vacuum to ACK DPS 124 before sending the start command.
+                # Without this delay, DPS 2 arrives before the room selection is processed
+                # and the vacuum ignores the start command.
+                await asyncio.sleep(1)
+                await self.vacuum.async_set({TuyaCodes.START_PAUSE: True})
 
     async def async_will_remove_from_hass(self) -> None:
         """Handle removal from Home Assistant."""

--- a/custom_components/robovac/vacuum.py
+++ b/custom_components/robovac/vacuum.py
@@ -81,6 +81,15 @@ def _build_protobuf_room_clean(
 ) -> str:
     """Build a base64-encoded protobuf SelectRoomsClean command."""
 
+    def validate_uint(name: str, value: Any) -> int:
+        if not isinstance(value, int) or value < 0:
+            raise ValueError(f"{name} must be a non-negative integer")
+        return value
+
+    room_ids = [validate_uint("room_id", room_id) for room_id in room_ids]
+    clean_times = validate_uint("clean_times", clean_times)
+    map_id = validate_uint("map_id", map_id)
+
     def vi(n: int) -> bytes:
         result: list[int] = []
         while True:

--- a/tests/test_vacuum/test_vacuum_commands.py
+++ b/tests/test_vacuum/test_vacuum_commands.py
@@ -301,6 +301,45 @@ async def test_room_clean_accepts_single_room_id_for_dps_152(
 
 
 @pytest.mark.asyncio
+async def test_room_clean_rejects_negative_values_for_dps_152(
+    mock_l60, mock_l60_data
+) -> None:
+    """Test roomClean rejects negative protobuf values."""
+    with patch("custom_components.robovac.vacuum.RoboVac", return_value=mock_l60):
+        entity = RoboVacEntity(mock_l60_data)
+
+        with pytest.raises(ValueError, match="room_id must be a non-negative integer"):
+            await entity.async_send_command(
+                "roomClean",
+                {"room_ids": [-1], "map_id": 1},
+            )
+
+        mock_l60.async_set.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_room_clean_legacy_path_still_uses_room_clean_dps(
+    mock_robovac, mock_vacuum_data
+) -> None:
+    """Test roomClean preserves the legacy DPS 124 JSON path."""
+    with (
+        patch("custom_components.robovac.vacuum.RoboVac", return_value=mock_robovac),
+        patch("custom_components.robovac.vacuum.asyncio.sleep", new_callable=AsyncMock) as sleep,
+    ):
+        entity = RoboVacEntity(mock_vacuum_data)
+
+        await entity.async_send_command(
+            "roomClean",
+            {"room_ids": [2], "count": 1},
+        )
+
+        first_call, second_call = mock_robovac.async_set.await_args_list
+        assert list(first_call.args[0]) == ["124"]
+        assert second_call.args[0] == {"2": True}
+        sleep.assert_awaited_once_with(1)
+
+
+@pytest.mark.asyncio
 async def test_async_update(mock_robovac, mock_vacuum_data) -> None:
     """Test the async_update method."""
     # Arrange

--- a/tests/test_vacuum/test_vacuum_commands.py
+++ b/tests/test_vacuum/test_vacuum_commands.py
@@ -269,6 +269,38 @@ async def test_async_send_command(mock_robovac, mock_vacuum_data) -> None:
 
 
 @pytest.mark.asyncio
+async def test_room_clean_uses_protobuf_for_dps_152(
+    mock_l60, mock_l60_data
+) -> None:
+    """Test roomClean sends protobuf payloads on DPS 152 models."""
+    with patch("custom_components.robovac.vacuum.RoboVac", return_value=mock_l60):
+        entity = RoboVacEntity(mock_l60_data)
+
+        await entity.async_send_command(
+            "roomClean",
+            {"room_ids": [2], "map_id": 3},
+        )
+
+        mock_l60.async_set.assert_called_once_with({"152": "DggBIgoKBAgCEAEQARgD"})
+
+
+@pytest.mark.asyncio
+async def test_room_clean_accepts_single_room_id_for_dps_152(
+    mock_l60, mock_l60_data
+) -> None:
+    """Test roomClean accepts a single integer room id on DPS 152 models."""
+    with patch("custom_components.robovac.vacuum.RoboVac", return_value=mock_l60):
+        entity = RoboVacEntity(mock_l60_data)
+
+        await entity.async_send_command(
+            "room_clean",
+            {"roomIds": 3, "mapId": 1},
+        )
+
+        mock_l60.async_set.assert_called_once_with({"152": "DggBIgoKBAgDEAEQARgB"})
+
+
+@pytest.mark.asyncio
 async def test_async_update(mock_robovac, mock_vacuum_data) -> None:
     """Test the async_update method."""
     # Arrange


### PR DESCRIPTION
Closing this draft in favor of #423, which already covers the same core L60 / DPS 152 roomClean support and has maintainer approval.

The only potentially useful follow-up pieces from this branch were validation/tests and explicit `map_id` handling, but those can be discussed on #423 or in a smaller follow-up if needed.