### PR TITLE
feat: Add native Home Assistant clean segment support

### DIFF
--- a/custom_components/robovac/config_flow.py
+++ b/custom_components/robovac/config_flow.py
@@ -45,7 +45,13 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 
-from .const import CONF_AUTODISCOVERY, CONF_VACS, DOMAIN
+from .const import (
+    CONF_AUTODISCOVERY,
+    CONF_ROOM_SEGMENT_MAP_ID,
+    CONF_ROOM_SEGMENTS,
+    CONF_VACS,
+    DOMAIN,
+)
 from .countries import (
     get_phone_code_by_country_code,
     get_phone_code_by_region,
@@ -283,6 +289,12 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 updated_vacuums[self.selected_vacuum][CONF_IP_ADDRESS] = user_input[
                     CONF_IP_ADDRESS
                 ]
+            updated_vacuums[self.selected_vacuum][CONF_ROOM_SEGMENT_MAP_ID] = (
+                user_input[CONF_ROOM_SEGMENT_MAP_ID]
+            )
+            updated_vacuums[self.selected_vacuum][CONF_ROOM_SEGMENTS] = user_input[
+                CONF_ROOM_SEGMENTS
+            ]
 
             self.hass.config_entries.async_update_entry(
                 self.config_entry,
@@ -300,6 +312,14 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 vol.Optional(
                     CONF_IP_ADDRESS,
                     default=vacuums[self.selected_vacuum].get(CONF_IP_ADDRESS),
+                ): str,
+                vol.Required(
+                    CONF_ROOM_SEGMENT_MAP_ID,
+                    default=vacuums[self.selected_vacuum].get(CONF_ROOM_SEGMENT_MAP_ID, 1),
+                ): int,
+                vol.Optional(
+                    CONF_ROOM_SEGMENTS,
+                    default=vacuums[self.selected_vacuum].get(CONF_ROOM_SEGMENTS, ""),
                 ): str,
             }
         )

--- a/custom_components/robovac/config_flow.py
+++ b/custom_components/robovac/config_flow.py
@@ -290,11 +290,15 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     CONF_IP_ADDRESS
                 ]
             updated_vacuums[self.selected_vacuum][CONF_ROOM_SEGMENT_MAP_ID] = (
-                user_input[CONF_ROOM_SEGMENT_MAP_ID]
+                user_input.get(
+                    CONF_ROOM_SEGMENT_MAP_ID,
+                    vacuums[self.selected_vacuum].get(CONF_ROOM_SEGMENT_MAP_ID, 1),
+                )
             )
-            updated_vacuums[self.selected_vacuum][CONF_ROOM_SEGMENTS] = user_input[
-                CONF_ROOM_SEGMENTS
-            ]
+            updated_vacuums[self.selected_vacuum][CONF_ROOM_SEGMENTS] = user_input.get(
+                CONF_ROOM_SEGMENTS,
+                vacuums[self.selected_vacuum].get(CONF_ROOM_SEGMENTS, ""),
+            )
 
             self.hass.config_entries.async_update_entry(
                 self.config_entry,

--- a/custom_components/robovac/const.py
+++ b/custom_components/robovac/const.py
@@ -3,6 +3,8 @@
 DOMAIN = "robovac"
 CONF_VACS = "vacuums"
 CONF_AUTODISCOVERY = "autodiscovery"
+CONF_ROOM_SEGMENT_MAP_ID = "room_segment_map_id"
+CONF_ROOM_SEGMENTS = "room_segments"
 REFRESH_RATE = 60
 PING_RATE = 10
 TIMEOUT = 5

--- a/custom_components/robovac/strings.json
+++ b/custom_components/robovac/strings.json
@@ -38,11 +38,15 @@
                 "title": "Edit vacuum",
                 "data": {
                     "autodiscovery": "Enable autodiscovery",
-                    "ip_address": "IP Address"
+                    "ip_address": "IP Address",
+                    "room_segment_map_id": "Room segment map ID",
+                    "room_segments": "Room segments"
                 },
                 "data_description": {
                     "autodiscovery": "Automatically find the vacuum on the network.",
-                    "ip_address": "The static IP address of your vacuum on your local network (optional if autodiscovery is enabled)."
+                    "ip_address": "The static IP address of your vacuum on your local network (optional if autodiscovery is enabled).",
+                    "room_segment_map_id": "The map ID used when cleaning configured room segments.",
+                    "room_segments": "Comma-separated room segments in id:name format, for example 1:Kitchen,2:Living Room."
                 },
                 "description": "Autodiscovery will automatically update the IP address"
             }

--- a/custom_components/robovac/translations/cy.json
+++ b/custom_components/robovac/translations/cy.json
@@ -38,11 +38,15 @@
                 "title": "Golygu sugnwr llwch",
                 "data": {
                     "autodiscovery": "Galluogi awto-ddarganfod",
-                    "ip_address": "Cyfeiriad IP"
+                    "ip_address": "Cyfeiriad IP",
+                    "room_segment_map_id": "Room segment map ID",
+                    "room_segments": "Room segments"
                 },
                 "data_description": {
                     "autodiscovery": "Dod o hyd i'r sugnwr llwch yn awtomatig ar y rhwydwaith.",
-                    "ip_address": "Cyfeiriad IP statig eich sugnwr llwch ar eich rhwydwaith lleol (dewisol os yw awto-ddarganfod wedi'i alluogi)."
+                    "ip_address": "Cyfeiriad IP statig eich sugnwr llwch ar eich rhwydwaith lleol (dewisol os yw awto-ddarganfod wedi'i alluogi).",
+                    "room_segment_map_id": "The map ID used when cleaning configured room segments.",
+                    "room_segments": "Comma-separated room segments in id:name format, for example 1:Kitchen,2:Living Room."
                 },
                 "description": "Bydd awto-ddarganfod yn diweddaru'r cyfeiriad IP yn awtomatig"
             }

--- a/custom_components/robovac/translations/de.json
+++ b/custom_components/robovac/translations/de.json
@@ -38,11 +38,15 @@
                 "title": "Staubsauger bearbeiten",
                 "data": {
                     "autodiscovery": "Autodiscovery aktivieren",
-                    "ip_address": "IP-Adresse"
+                    "ip_address": "IP-Adresse",
+                    "room_segment_map_id": "Room segment map ID",
+                    "room_segments": "Room segments"
                 },
                 "data_description": {
                     "autodiscovery": "Den Staubsauger automatisch im Netzwerk finden.",
-                    "ip_address": "Die statische IP-Adresse Ihres Staubsaugers in Ihrem lokalen Netzwerk (optional, wenn Autodiscovery aktiviert ist)."
+                    "ip_address": "Die statische IP-Adresse Ihres Staubsaugers in Ihrem lokalen Netzwerk (optional, wenn Autodiscovery aktiviert ist).",
+                    "room_segment_map_id": "The map ID used when cleaning configured room segments.",
+                    "room_segments": "Comma-separated room segments in id:name format, for example 1:Kitchen,2:Living Room."
                 },
                 "description": "Autodiscovery aktualisiert die IP-Adresse automatisch"
             }

--- a/custom_components/robovac/translations/en.json
+++ b/custom_components/robovac/translations/en.json
@@ -38,11 +38,15 @@
                 "title": "Edit vacuum",
                 "data": {
                     "autodiscovery": "Enable autodiscovery",
-                    "ip_address": "IP Address"
+                    "ip_address": "IP Address",
+                    "room_segment_map_id": "Room segment map ID",
+                    "room_segments": "Room segments"
                 },
                 "data_description": {
                     "autodiscovery": "Automatically find the vacuum on the network.",
-                    "ip_address": "The static IP address of your vacuum on your local network (optional if autodiscovery is enabled)."
+                    "ip_address": "The static IP address of your vacuum on your local network (optional if autodiscovery is enabled).",
+                    "room_segment_map_id": "The map ID used when cleaning configured room segments.",
+                    "room_segments": "Comma-separated room segments in id:name format, for example 1:Kitchen,2:Living Room."
                 },
                 "description": "Autodiscovery will automatically update the IP address"
             }

--- a/custom_components/robovac/translations/es.json
+++ b/custom_components/robovac/translations/es.json
@@ -38,11 +38,15 @@
                 "title": "Editar aspiradora",
                 "data": {
                     "autodiscovery": "Habilitar autodescubrimiento",
-                    "ip_address": "Dirección IP"
+                    "ip_address": "Dirección IP",
+                    "room_segment_map_id": "Room segment map ID",
+                    "room_segments": "Room segments"
                 },
                 "data_description": {
                     "autodiscovery": "Encontrar automáticamente la aspiradora en la red.",
-                    "ip_address": "La dirección IP estática de su aspiradora en su red local (opcional si el autodescubrimiento está habilitado)."
+                    "ip_address": "La dirección IP estática de su aspiradora en su red local (opcional si el autodescubrimiento está habilitado).",
+                    "room_segment_map_id": "The map ID used when cleaning configured room segments.",
+                    "room_segments": "Comma-separated room segments in id:name format, for example 1:Kitchen,2:Living Room."
                 },
                 "description": "El autodescubrimiento actualizará automáticamente la dirección IP"
             }

--- a/custom_components/robovac/translations/fr.json
+++ b/custom_components/robovac/translations/fr.json
@@ -38,11 +38,15 @@
                 "title": "Modifier l'aspirateur",
                 "data": {
                     "autodiscovery": "Activer la découverte automatique",
-                    "ip_address": "Adresse IP"
+                    "ip_address": "Adresse IP",
+                    "room_segment_map_id": "Room segment map ID",
+                    "room_segments": "Room segments"
                 },
                 "data_description": {
                     "autodiscovery": "Trouver automatiquement l'aspirateur sur le réseau.",
-                    "ip_address": "L'adresse IP statique de votre aspirateur sur votre réseau local (optionnel si la découverte automatique est activée)."
+                    "ip_address": "L'adresse IP statique de votre aspirateur sur votre réseau local (optionnel si la découverte automatique est activée).",
+                    "room_segment_map_id": "The map ID used when cleaning configured room segments.",
+                    "room_segments": "Comma-separated room segments in id:name format, for example 1:Kitchen,2:Living Room."
                 },
                 "description": "La découverte automatique mettra à jour automatiquement l'adresse IP"
             }

--- a/custom_components/robovac/translations/it.json
+++ b/custom_components/robovac/translations/it.json
@@ -38,11 +38,15 @@
                 "title": "Modifica aspirapolvere",
                 "data": {
                     "autodiscovery": "Abilita rilevamento automatico",
-                    "ip_address": "Indirizzo IP"
+                    "ip_address": "Indirizzo IP",
+                    "room_segment_map_id": "Room segment map ID",
+                    "room_segments": "Room segments"
                 },
                 "data_description": {
                     "autodiscovery": "Trova automaticamente l'aspirapolvere sulla rete.",
-                    "ip_address": "L'indirizzo IP statico del tuo aspirapolvere sulla tua rete locale (opzionale se il rilevamento automatico è abilitato)."
+                    "ip_address": "L'indirizzo IP statico del tuo aspirapolvere sulla tua rete locale (opzionale se il rilevamento automatico è abilitato).",
+                    "room_segment_map_id": "The map ID used when cleaning configured room segments.",
+                    "room_segments": "Comma-separated room segments in id:name format, for example 1:Kitchen,2:Living Room."
                 },
                 "description": "Il rilevamento automatico aggiornerà automaticamente l'indirizzo IP"
             }

--- a/custom_components/robovac/translations/nl.json
+++ b/custom_components/robovac/translations/nl.json
@@ -38,11 +38,15 @@
                 "title": "Stofzuiger bewerken",
                 "data": {
                     "autodiscovery": "Automatische detectie inschakelen",
-                    "ip_address": "IP-adres"
+                    "ip_address": "IP-adres",
+                    "room_segment_map_id": "Room segment map ID",
+                    "room_segments": "Room segments"
                 },
                 "data_description": {
                     "autodiscovery": "Vind de stofzuiger automatisch op het netwerk.",
-                    "ip_address": "Het statische IP-adres van uw stofzuiger op uw lokale netwerk (optioneel als automatische detectie is ingeschakeld)."
+                    "ip_address": "Het statische IP-adres van uw stofzuiger op uw lokale netwerk (optioneel als automatische detectie is ingeschakeld).",
+                    "room_segment_map_id": "The map ID used when cleaning configured room segments.",
+                    "room_segments": "Comma-separated room segments in id:name format, for example 1:Kitchen,2:Living Room."
                 },
                 "description": "Automatische detectie zal het IP-adres automatisch bijwerken"
             }

--- a/custom_components/robovac/translations/pt.json
+++ b/custom_components/robovac/translations/pt.json
@@ -38,11 +38,15 @@
                 "title": "Editar aspirador",
                 "data": {
                     "autodiscovery": "Ativar descoberta automática",
-                    "ip_address": "Endereço IP"
+                    "ip_address": "Endereço IP",
+                    "room_segment_map_id": "Room segment map ID",
+                    "room_segments": "Room segments"
                 },
                 "data_description": {
                     "autodiscovery": "Encontrar automaticamente o aspirador na rede.",
-                    "ip_address": "O endereço IP estático do seu aspirador na sua rede local (opcional se a descoberta automática estiver ativada)."
+                    "ip_address": "O endereço IP estático do seu aspirador na sua rede local (opcional se a descoberta automática estiver ativada).",
+                    "room_segment_map_id": "The map ID used when cleaning configured room segments.",
+                    "room_segments": "Comma-separated room segments in id:name format, for example 1:Kitchen,2:Living Room."
                 },
                 "description": "A descoberta automática atualizará automaticamente o endereço IP"
             }

--- a/custom_components/robovac/vacuum.py
+++ b/custom_components/robovac/vacuum.py
@@ -19,6 +19,7 @@ This module provides the vacuum entity integration for Eufy Robovac devices.
 from __future__ import annotations
 import asyncio
 import base64
+from dataclasses import dataclass
 from datetime import timedelta
 from enum import StrEnum
 import json
@@ -54,9 +55,17 @@ from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import CONF_VACS, DOMAIN, PING_RATE, REFRESH_RATE, TIMEOUT
-from .eufywebapi import EufyLogon
+from .const import (
+    CONF_ROOM_SEGMENT_MAP_ID,
+    CONF_ROOM_SEGMENTS,
+    CONF_VACS,
+    DOMAIN,
+    PING_RATE,
+    REFRESH_RATE,
+    TIMEOUT,
+)
 from .errors import getErrorMessage
+from .eufywebapi import EufyLogon
 from .proto_decode import (
     build_t2320_room_clean_mode,
     decode_clean_param_response,
@@ -173,6 +182,50 @@ ROOM_DISCOVERY_STRATEGIES: dict[str, dict[str, str]] = {
 # ⚡ Bolt optimization: Pre-calculate valid VacuumActivity values into a set
 # to avoid O(n) list comprehension on every property getter access
 VACUUM_ACTIVITY_VALUES = {activity.value for activity in VacuumActivity}
+
+
+@dataclass(frozen=True)
+class RoomSegment:
+    """Cleanable room segment for a RoboVac map."""
+
+    id: int
+    name: str
+
+
+@dataclass(frozen=True)
+class RoomSegmentMap:
+    """Cleanable room segments and map id for a RoboVac."""
+
+    map_id: int
+    segments: tuple[RoomSegment, ...]
+
+
+def _parse_room_segments(raw_segments: str | None) -> tuple[RoomSegment, ...]:
+    """Parse configured room segments from 'id:name' comma-separated text."""
+    if not raw_segments:
+        return ()
+
+    segments: list[RoomSegment] = []
+    for raw_segment in raw_segments.split(","):
+        segment = raw_segment.strip()
+        if not segment:
+            continue
+        raw_id, separator, name = segment.partition(":")
+        if not separator:
+            _LOGGER.warning("Ignoring room segment without ':' separator: %s", segment)
+            continue
+        try:
+            segment_id = int(raw_id.strip())
+        except ValueError:
+            _LOGGER.warning("Ignoring room segment with invalid id: %s", segment)
+            continue
+        name = name.strip()
+        if not name:
+            _LOGGER.warning("Ignoring room segment without name: %s", segment)
+            continue
+        segments.append(RoomSegment(segment_id, name))
+
+    return tuple(segments)
 
 
 async def async_setup_entry(
@@ -624,6 +677,11 @@ class RoboVacEntity(StateVacuumEntity):
         self._attr_model_code = item[CONF_MODEL]
         self._attr_ip_address = item[CONF_IP_ADDRESS]
         self._attr_access_token = item[CONF_ACCESS_TOKEN]
+        configured_segments = _parse_room_segments(item.get(CONF_ROOM_SEGMENTS))
+        self._room_segment_map = RoomSegmentMap(
+            map_id=int(item.get(CONF_ROOM_SEGMENT_MAP_ID, 1)),
+            segments=configured_segments,
+        )
         self.vacuum: RoboVac | None = None
         self.update_failures = 0
         self.tuyastatus: dict[str, Any] | None = None
@@ -674,6 +732,8 @@ class RoboVacEntity(StateVacuumEntity):
         if self.vacuum is not None:
             # Get the supported features from the vacuum
             features = int(self.vacuum.getHomeAssistantFeatures())
+            if self._room_segment_map.segments:
+                features |= int(VacuumEntityFeature.CLEAN_AREA)
             self._attr_supported_features = VacuumEntityFeature(features)
             self._attr_robovac_supported = self.vacuum.getRoboVacFeatures()
             self._attr_activity_mapping = self.vacuum.getRoboVacActivityMapping()
@@ -713,6 +773,41 @@ class RoboVacEntity(StateVacuumEntity):
             model=item[CONF_DESCRIPTION],
             connections={
                 (CONNECTION_NETWORK_MAC, item[CONF_MAC]),
+            },
+        )
+
+    async def async_get_segments(self) -> list[Segment]:
+        """Return cleanable segments for Home Assistant clean-area mapping."""
+        return [
+            Segment(id=str(segment.id), name=segment.name)
+            for segment in self._room_segment_map.segments
+        ]
+
+    async def async_clean_segments(self, segment_ids: list[str], **kwargs: Any) -> None:
+        """Clean Home Assistant native clean-area segments."""
+        known_room_ids = {segment.id for segment in self._room_segment_map.segments}
+        room_ids: list[int] = []
+        for segment_id in segment_ids:
+            try:
+                room_id = int(segment_id)
+            except (TypeError, ValueError):
+                _LOGGER.warning("Ignoring invalid segment id for %s: %s", self.name, segment_id)
+                continue
+            if room_id not in known_room_ids:
+                _LOGGER.warning("Ignoring unknown segment id for %s: %s", self.name, segment_id)
+                continue
+            room_ids.append(room_id)
+
+        if not room_ids:
+            _LOGGER.warning("No valid segment ids supplied for %s: %s", self.name, segment_ids)
+            return
+
+        await self.async_send_command(
+            "roomClean",
+            {
+                "room_ids": room_ids,
+                "map_id": self._room_segment_map.map_id,
+                "count": int(kwargs.get("count", kwargs.get("repeats", 1))),
             },
         )
 

--- a/custom_components/robovac/vacuum.py
+++ b/custom_components/robovac/vacuum.py
@@ -228,6 +228,26 @@ def _parse_room_segments(raw_segments: str | None) -> tuple[RoomSegment, ...]:
     return tuple(segments)
 
 
+def _parse_room_segment_map_id(raw_map_id: Any) -> int:
+    """Parse configured room segment map id, falling back to the default map."""
+    if raw_map_id in (None, ""):
+        return 1
+    try:
+        return int(raw_map_id)
+    except (TypeError, ValueError):
+        _LOGGER.warning("Ignoring invalid room segment map id: %s", raw_map_id)
+        return 1
+
+
+def _parse_clean_count(raw_count: Any) -> int:
+    """Parse room clean repeat count, falling back to one pass."""
+    try:
+        return max(1, int(raw_count))
+    except (TypeError, ValueError):
+        _LOGGER.warning("Ignoring invalid room clean count: %s", raw_count)
+        return 1
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -679,7 +699,7 @@ class RoboVacEntity(StateVacuumEntity):
         self._attr_access_token = item[CONF_ACCESS_TOKEN]
         configured_segments = _parse_room_segments(item.get(CONF_ROOM_SEGMENTS))
         self._room_segment_map = RoomSegmentMap(
-            map_id=int(item.get(CONF_ROOM_SEGMENT_MAP_ID, 1)),
+            map_id=_parse_room_segment_map_id(item.get(CONF_ROOM_SEGMENT_MAP_ID)),
             segments=configured_segments,
         )
         self.vacuum: RoboVac | None = None
@@ -773,41 +793,6 @@ class RoboVacEntity(StateVacuumEntity):
             model=item[CONF_DESCRIPTION],
             connections={
                 (CONNECTION_NETWORK_MAC, item[CONF_MAC]),
-            },
-        )
-
-    async def async_get_segments(self) -> list[Segment]:
-        """Return cleanable segments for Home Assistant clean-area mapping."""
-        return [
-            Segment(id=str(segment.id), name=segment.name)
-            for segment in self._room_segment_map.segments
-        ]
-
-    async def async_clean_segments(self, segment_ids: list[str], **kwargs: Any) -> None:
-        """Clean Home Assistant native clean-area segments."""
-        known_room_ids = {segment.id for segment in self._room_segment_map.segments}
-        room_ids: list[int] = []
-        for segment_id in segment_ids:
-            try:
-                room_id = int(segment_id)
-            except (TypeError, ValueError):
-                _LOGGER.warning("Ignoring invalid segment id for %s: %s", self.name, segment_id)
-                continue
-            if room_id not in known_room_ids:
-                _LOGGER.warning("Ignoring unknown segment id for %s: %s", self.name, segment_id)
-                continue
-            room_ids.append(room_id)
-
-        if not room_ids:
-            _LOGGER.warning("No valid segment ids supplied for %s: %s", self.name, segment_ids)
-            return
-
-        await self.async_send_command(
-            "roomClean",
-            {
-                "room_ids": room_ids,
-                "map_id": self._room_segment_map.map_id,
-                "count": int(kwargs.get("count", kwargs.get("repeats", 1))),
             },
         )
 
@@ -1394,7 +1379,13 @@ class RoboVacEntity(StateVacuumEntity):
         return None
 
     async def async_get_segments(self) -> list[Segment]:
-        """Return known T2320 room segments for HA callers that support it."""
+        """Return cleanable segments for Home Assistant clean-area mapping."""
+        if self._room_segment_map.segments:
+            return [
+                Segment(id=str(segment.id), name=segment.name)
+                for segment in self._room_segment_map.segments
+            ]
+
         if not self._attr_room_names:
             await self._async_fetch_rooms_from_cloud_once()
         if not self._attr_room_names:
@@ -1405,10 +1396,52 @@ class RoboVacEntity(StateVacuumEntity):
         ]
 
     async def async_clean_segments(self, segment_ids: list[str], **kwargs: Any) -> None:
-        """Clean selected T2320 room segments."""
+        """Clean Home Assistant native clean-area segments."""
+        clean_count = kwargs.get("count", kwargs.get("repeats", 1))
+
+        if self._room_segment_map.segments:
+            known_room_ids = {segment.id for segment in self._room_segment_map.segments}
+            room_ids: list[int] = []
+            for segment_id in segment_ids:
+                try:
+                    room_id = int(segment_id)
+                except (TypeError, ValueError):
+                    _LOGGER.warning(
+                        "Ignoring invalid segment id for %s: %s",
+                        self.name,
+                        segment_id,
+                    )
+                    continue
+                if room_id not in known_room_ids:
+                    _LOGGER.warning(
+                        "Ignoring unknown segment id for %s: %s",
+                        self.name,
+                        segment_id,
+                    )
+                    continue
+                room_ids.append(room_id)
+
+            if not room_ids:
+                _LOGGER.warning(
+                    "No valid segment ids supplied for %s: %s",
+                    self.name,
+                    segment_ids,
+                )
+                return
+
+            await self.async_send_command(
+                "roomClean",
+                {
+                    "room_ids": room_ids,
+                    "map_id": self._room_segment_map.map_id,
+                    "count": _parse_clean_count(clean_count),
+                },
+            )
+            return
+
         await self.async_send_command(
             "roomClean",
-            {"roomIds": segment_ids, "count": kwargs.get("count", 1)},
+            {"roomIds": segment_ids, "count": clean_count},
         )
 
     async def async_locate(self, **kwargs: Any) -> None:
@@ -1655,6 +1688,7 @@ class RoboVacEntity(StateVacuumEntity):
                 self.get_dps_code("BOOST_IQ"): new_value
             })
         elif command in ("roomClean", "room_clean", "app_segment_clean") and params is not None:
+            map_id: Any | None = None
             if isinstance(params, list):
                 # HA may pass params as a list of single-key dicts.
                 if all(isinstance(item, dict) for item in params):
@@ -1664,12 +1698,16 @@ class RoboVacEntity(StateVacuumEntity):
                     params = merged
                     room_ids = params.get("roomIds") or params.get("room_ids", [1])
                     count = params.get("count", 1)
+                    map_id = (
+                        params["mapId"] if "mapId" in params else params.get("map_id")
+                    )
                 else:
                     room_ids = params
                     count = 1
             elif isinstance(params, dict):
                 room_ids = params.get("roomIds") or params.get("room_ids", [1])
                 count = params.get("count", 1)
+                map_id = params["mapId"] if "mapId" in params else params.get("map_id")
             else:
                 _LOGGER.error("roomClean: unexpected params type %s", type(params).__name__)
                 return
@@ -1728,6 +1766,8 @@ class RoboVacEntity(StateVacuumEntity):
                 await self.vacuum.async_set({mode_dps: proto_cmd})
             else:
                 clean_request = {"roomIds": room_ids, "cleanTimes": count}
+                if map_id is not None:
+                    clean_request["mapId"] = map_id
                 method_call = {
                     "method": "selectRoomsClean",
                     "data": clean_request,

--- a/tests/test_options_flow.py
+++ b/tests/test_options_flow.py
@@ -21,7 +21,13 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 
 from custom_components.robovac.config_flow import OptionsFlowHandler
-from custom_components.robovac.const import DOMAIN, CONF_AUTODISCOVERY, CONF_VACS
+from custom_components.robovac.const import (
+    CONF_AUTODISCOVERY,
+    CONF_ROOM_SEGMENT_MAP_ID,
+    CONF_ROOM_SEGMENTS,
+    CONF_VACS,
+    DOMAIN,
+)
 from custom_components.robovac.robovac import RoboVac
 
 
@@ -115,6 +121,8 @@ async def test_options_flow_edit_default_values(hass: HomeAssistant, mock_config
     # Verify that the form contains the expected fields
     assert CONF_AUTODISCOVERY in result["data_schema"].schema
     assert CONF_IP_ADDRESS in result["data_schema"].schema
+    assert CONF_ROOM_SEGMENT_MAP_ID in result["data_schema"].schema
+    assert CONF_ROOM_SEGMENTS in result["data_schema"].schema
 
 
 @pytest.mark.asyncio
@@ -146,6 +154,8 @@ async def test_options_flow_edit_custom_values(hass: HomeAssistant) -> None:
     # Verify that the form contains the expected fields
     assert CONF_AUTODISCOVERY in result["data_schema"].schema
     assert CONF_IP_ADDRESS in result["data_schema"].schema
+    assert CONF_ROOM_SEGMENT_MAP_ID in result["data_schema"].schema
+    assert CONF_ROOM_SEGMENTS in result["data_schema"].schema
 
 
 @pytest.mark.asyncio
@@ -182,6 +192,8 @@ async def test_options_flow_edit_submit_with_ip(hass: HomeAssistant, mock_config
             {
                 CONF_AUTODISCOVERY: False,
                 CONF_IP_ADDRESS: "192.168.1.100",
+                CONF_ROOM_SEGMENT_MAP_ID: 3,
+                CONF_ROOM_SEGMENTS: "1:Kitchen,2:Living Room",
             }
         )
 
@@ -229,6 +241,8 @@ async def test_options_flow_edit_submit_without_ip(
             {
                 CONF_AUTODISCOVERY: True,
                 CONF_IP_ADDRESS: "",
+                CONF_ROOM_SEGMENT_MAP_ID: 1,
+                CONF_ROOM_SEGMENTS: "",
             }
         )
 

--- a/tests/test_vacuum/test_vacuum_commands.py
+++ b/tests/test_vacuum/test_vacuum_commands.py
@@ -1,5 +1,8 @@
 """Tests for the RoboVac vacuum entity commands."""
 
+import base64
+import json
+
 import pytest
 from typing import Any
 from unittest.mock import patch, MagicMock, AsyncMock, call
@@ -475,6 +478,89 @@ async def test_async_send_command(mock_robovac, mock_vacuum_data) -> None:
         entity._attr_boost_iq = True
         await entity.async_send_command("boostIQ")
         mock_robovac.async_set.assert_called_once_with({"118": False})
+
+
+@pytest.mark.asyncio
+async def test_room_clean_includes_map_id(mock_robovac, mock_vacuum_data) -> None:
+    """Test roomClean forwards the configured map ID when provided."""
+    with patch("custom_components.robovac.vacuum.RoboVac", return_value=mock_robovac):
+        entity = RoboVacEntity(mock_vacuum_data)
+
+    await entity.async_send_command(
+        "roomClean",
+        {
+            "room_ids": [2],
+            "map_id": 3,
+            "count": 2,
+        },
+    )
+
+    first_call = mock_robovac.async_set.await_args_list[0]
+    payload = first_call.args[0]["124"]
+    method_call = json.loads(base64.b64decode(payload).decode("utf8"))
+
+    assert method_call["method"] == "selectRoomsClean"
+    assert method_call["data"] == {
+        "roomIds": [2],
+        "cleanTimes": 2,
+        "mapId": 3,
+    }
+
+
+@pytest.mark.asyncio
+async def test_room_clean_accepts_list_params_with_map_id(
+    mock_robovac, mock_vacuum_data
+) -> None:
+    """Test roomClean merges Home Assistant list params and preserves map ID."""
+    with patch("custom_components.robovac.vacuum.RoboVac", return_value=mock_robovac):
+        entity = RoboVacEntity(mock_vacuum_data)
+
+    await entity.async_send_command(
+        "roomClean",
+        [{"roomIds": [2]}, {"mapId": 0}, {"count": 2}],
+    )
+
+    first_call = mock_robovac.async_set.await_args_list[0]
+    payload = first_call.args[0]["124"]
+    method_call = json.loads(base64.b64decode(payload).decode("utf8"))
+
+    assert method_call["method"] == "selectRoomsClean"
+    assert method_call["data"] == {
+        "roomIds": [2],
+        "cleanTimes": 2,
+        "mapId": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_room_clean_accepts_room_id_list(mock_robovac, mock_vacuum_data) -> None:
+    """Test roomClean accepts a direct list of room IDs."""
+    with patch("custom_components.robovac.vacuum.RoboVac", return_value=mock_robovac):
+        entity = RoboVacEntity(mock_vacuum_data)
+
+    await entity.async_send_command("roomClean", [2, 3])
+
+    first_call = mock_robovac.async_set.await_args_list[0]
+    payload = first_call.args[0]["124"]
+    method_call = json.loads(base64.b64decode(payload).decode("utf8"))
+
+    assert method_call["data"] == {
+        "roomIds": [2, 3],
+        "cleanTimes": 1,
+    }
+
+
+@pytest.mark.asyncio
+async def test_room_clean_ignores_unexpected_params(
+    mock_robovac, mock_vacuum_data
+) -> None:
+    """Test roomClean ignores unsupported parameter shapes."""
+    with patch("custom_components.robovac.vacuum.RoboVac", return_value=mock_robovac):
+        entity = RoboVacEntity(mock_vacuum_data)
+
+    await entity.async_send_command("roomClean", "bad params")
+
+    mock_robovac.async_set.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_vacuum/test_vacuum_entity.py
+++ b/tests/test_vacuum/test_vacuum_entity.py
@@ -3,9 +3,9 @@
 import base64
 import pytest
 from typing import Any
-from unittest.mock import patch, MagicMock
+from unittest.mock import AsyncMock, patch, MagicMock
 
-from homeassistant.components.vacuum import VacuumActivity
+from homeassistant.components.vacuum import VacuumActivity, VacuumEntityFeature
 from homeassistant.const import (
     CONF_ACCESS_TOKEN,
     CONF_DESCRIPTION,
@@ -15,8 +15,15 @@ from homeassistant.const import (
     CONF_MODEL,
     CONF_NAME,
 )
+from custom_components.robovac.const import CONF_ROOM_SEGMENT_MAP_ID, CONF_ROOM_SEGMENTS
 from custom_components.robovac.robovac import RoboVac
-from custom_components.robovac.vacuum import ATTR_ERROR, RoboVacEntity
+from custom_components.robovac.vacuum import (
+    ATTR_ERROR,
+    RoboVacEntity,
+    _parse_clean_count,
+    _parse_room_segment_map_id,
+    _parse_room_segments,
+)
 from custom_components.robovac.vacuums.base import TuyaCodes
 
 
@@ -459,6 +466,145 @@ async def test_update_entity_values(mock_robovac, mock_vacuum_data) -> None:
         assert entity.error_code == 0
         assert entity._attr_mode == "auto"
         assert entity._attr_fan_speed == "Standard"
+
+
+def test_parse_room_segments() -> None:
+    """Test configured room segment parsing."""
+    segments = _parse_room_segments(
+        "1:Kitchen, , bad, nope:Study, 2: Living Room, 3:"
+    )
+
+    assert [(segment.id, segment.name) for segment in segments] == [
+        (1, "Kitchen"),
+        (2, "Living Room"),
+    ]
+
+
+def test_room_segment_parser_fallbacks() -> None:
+    """Test defensive parsing for configured segment controls."""
+    assert _parse_room_segment_map_id(None) == 1
+    assert _parse_room_segment_map_id("") == 1
+    assert _parse_room_segment_map_id("bad") == 1
+    assert _parse_clean_count("bad") == 1
+    assert _parse_clean_count(0) == 1
+
+
+def test_clean_area_feature_enabled_only_with_segments(
+    mock_robovac, mock_vacuum_data
+) -> None:
+    """Test CLEAN_AREA is enabled only when segments are configured."""
+    with patch("custom_components.robovac.vacuum.RoboVac", return_value=mock_robovac):
+        entity = RoboVacEntity(mock_vacuum_data)
+        assert not entity.supported_features & VacuumEntityFeature.CLEAN_AREA
+
+    segmented_data = {
+        **mock_vacuum_data,
+        CONF_ROOM_SEGMENT_MAP_ID: 3,
+        CONF_ROOM_SEGMENTS: "1:Kitchen,2:Living Room",
+    }
+    with patch("custom_components.robovac.vacuum.RoboVac", return_value=mock_robovac):
+        entity = RoboVacEntity(segmented_data)
+        assert entity.supported_features & VacuumEntityFeature.CLEAN_AREA
+
+
+@pytest.mark.asyncio
+async def test_async_get_segments(mock_robovac, mock_vacuum_data) -> None:
+    """Test Home Assistant segment metadata is returned from configured rooms."""
+    data = {
+        **mock_vacuum_data,
+        CONF_ROOM_SEGMENT_MAP_ID: 3,
+        CONF_ROOM_SEGMENTS: "1:Kitchen,2:Living Room",
+    }
+
+    with patch("custom_components.robovac.vacuum.RoboVac", return_value=mock_robovac):
+        entity = RoboVacEntity(data)
+
+    segments = await entity.async_get_segments()
+
+    assert [(segment.id, segment.name) for segment in segments] == [
+        ("1", "Kitchen"),
+        ("2", "Living Room"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_async_get_segments_without_segments_returns_empty(
+    mock_robovac, mock_vacuum_data
+) -> None:
+    """Test no cleanable segments are exposed when none are configured/discovered."""
+    with patch("custom_components.robovac.vacuum.RoboVac", return_value=mock_robovac):
+        entity = RoboVacEntity(mock_vacuum_data)
+
+    assert await entity.async_get_segments() == []
+
+
+@pytest.mark.asyncio
+async def test_async_get_segments_uses_discovered_rooms(
+    mock_robovac, mock_vacuum_data
+) -> None:
+    """Test discovered room metadata is exposed when no manual segments exist."""
+    with patch("custom_components.robovac.vacuum.RoboVac", return_value=mock_robovac):
+        entity = RoboVacEntity(mock_vacuum_data)
+
+    entity._attr_room_names = {
+        "room_1": {"id": 1, "label": "Kitchen"},
+        "room_2": {"id": 2, "label": "Living Room"},
+    }
+
+    segments = await entity.async_get_segments()
+
+    assert [(segment.id, segment.name) for segment in segments] == [
+        ("1", "Kitchen"),
+        ("2", "Living Room"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_async_clean_segments_maps_to_room_clean(
+    mock_robovac, mock_vacuum_data
+) -> None:
+    """Test segment cleaning validates IDs and calls roomClean."""
+    data = {
+        **mock_vacuum_data,
+        CONF_ID: "test_robovac_id",
+        CONF_ROOM_SEGMENT_MAP_ID: 3,
+        CONF_ROOM_SEGMENTS: "1:Kitchen,2:Living Room",
+    }
+
+    with patch("custom_components.robovac.vacuum.RoboVac", return_value=mock_robovac):
+        entity = RoboVacEntity(data)
+
+    entity.async_send_command = AsyncMock()
+    await entity.async_clean_segments(["2", "bad", "99"], repeats=2)
+
+    entity.async_send_command.assert_awaited_once_with(
+        "roomClean",
+        {
+            "room_ids": [2],
+            "map_id": 3,
+            "count": 2,
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_clean_segments_ignores_empty_selection(
+    mock_robovac, mock_vacuum_data
+) -> None:
+    """Test segment cleaning does not dispatch when no supplied IDs are valid."""
+    data = {
+        **mock_vacuum_data,
+        CONF_ROOM_SEGMENT_MAP_ID: 3,
+        CONF_ROOM_SEGMENTS: "1:Kitchen,2:Living Room",
+    }
+
+    with patch("custom_components.robovac.vacuum.RoboVac", return_value=mock_robovac):
+        entity = RoboVacEntity(data)
+
+    entity.async_send_command = AsyncMock()
+    await entity.async_clean_segments(["bad", "99"])
+
+    entity.async_send_command.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds Home Assistant native clean segment support for RoboVac room cleaning:

- exposes configured room segments through `async_get_segments`
- enables `VacuumEntityFeature.CLEAN_AREA` when segments are configured
- maps Home Assistant segment cleaning back to the existing `roomClean` command
- adds options-flow fields for room segment map ID and `id:name` segment definitions

This is aimed at Home Assistant 2026.5's new Clean by area vacuum dialog.

## Notes

This does not hardcode any room IDs or device-specific maps. Users configure the map ID and segment list for each vacuum.

For models where `roomClean` already works, this should plug into the native Home Assistant UI directly. L60/protobuf models still need the lower-level roomClean payload fix from #423.

## Validation

- `python3 -m py_compile custom_components/robovac/vacuum.py custom_components/robovac/config_flow.py`