### PR TITLE
fix: Fix startup state recovery from partial DPS

### DIFF
--- a/custom_components/robovac/tuyalocalapi.py
+++ b/custom_components/robovac/tuyalocalapi.py
@@ -1207,6 +1207,7 @@ class TuyaDevice:
         message = Message(
             Message.GET_COMMAND, payload_bytes, encrypt=encrypt, device=self
         )
+        await self.async_connect()
         self._queue.append(message)
         response = await self.async_receive(message)
         if response is not None:

--- a/custom_components/robovac/tuyalocalapi.py
+++ b/custom_components/robovac/tuyalocalapi.py
@@ -1201,6 +1201,8 @@ class TuyaDevice:
             # the device sends after SET commands.  So just stay connected.
             await self.async_connect()
             return
+        if self._backoff is True:
+            return
         payload_dict = {"gwId": self.gateway_id, "devId": self.device_id}
         payload_bytes = json.dumps(payload_dict).encode("utf-8")
         encrypt = False if self.version < (3, 3) else True

--- a/custom_components/robovac/vacuum.py
+++ b/custom_components/robovac/vacuum.py
@@ -653,7 +653,7 @@ class RoboVacEntity(StateVacuumEntity):
                 self._attr_tuya_state
             )
         else:
-            self._attr_tuya_state = 0
+            self._attr_tuya_state = self._fallback_state_from_partial_dps()
 
         # Update error code attribute
         if error_code is not None and self.vacuum is not None:
@@ -665,6 +665,30 @@ class RoboVacEntity(StateVacuumEntity):
             )
         else:
             self._attr_error_code = 0
+
+    def _fallback_state_from_partial_dps(self) -> VacuumActivity | int:
+        """Infer a usable state from partial model DPS returned after startup."""
+        if self.tuyastatus is None:
+            return 0
+
+        known_state_codes = {
+            self.get_dps_code("STATUS"),
+            self.get_dps_code("MODE"),
+            self.get_dps_code("RETURN_HOME"),
+        }
+        battery_code = self.get_dps_code("BATTERY")
+        informative_dps = {
+            code for code, value in self.tuyastatus.items()
+            if value is not None and code and code != battery_code
+        }
+
+        # Some vacuums return partial availability/config DPS after restart
+        # without an explicit status DPS. Treat that as idle so HA leaves
+        # unknown, but do not infer state from single-field updates.
+        if len(informative_dps) >= 2 and not known_state_codes.intersection(self.tuyastatus):
+            return VacuumActivity.IDLE
+
+        return 0
 
     def _update_mode_and_fan_speed(self) -> None:
         """Update the mode and fan speed attributes."""

--- a/tests/test_vacuum/test_tuyalocalapi_async_get.py
+++ b/tests/test_vacuum/test_tuyalocalapi_async_get.py
@@ -1,0 +1,35 @@
+"""Tests for local Tuya status refresh behavior."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.robovac.tuyalocalapi import Message, TuyaDevice
+
+
+@pytest.mark.asyncio
+async def test_legacy_async_get_connects_before_waiting_for_response() -> None:
+    """Test legacy GET status refresh waits only after connection is established."""
+    device = TuyaDevice.__new__(TuyaDevice)
+    device.version = (3, 3)
+    device.gateway_id = "test-device"
+    device.device_id = "test-device"
+    device._queue = []
+    device._listeners = {}
+    device._connected = False
+
+    async def connect() -> None:
+        device._connected = True
+
+    async def receive(message: Message) -> None:
+        assert device._connected is True
+        assert device._queue == [message]
+
+    device.async_connect = AsyncMock(side_effect=connect)
+    device.async_receive = AsyncMock(side_effect=receive)
+
+    await device.async_get()
+
+    device.async_connect.assert_awaited_once()
+    device.async_receive.assert_awaited_once()
+    assert device._queue[0].command == Message.GET_COMMAND

--- a/tests/test_vacuum/test_tuyalocalapi_async_get.py
+++ b/tests/test_vacuum/test_tuyalocalapi_async_get.py
@@ -17,6 +17,7 @@ async def test_legacy_async_get_connects_before_waiting_for_response() -> None:
     device._queue = []
     device._listeners = {}
     device._connected = False
+    device._backoff = False
 
     async def connect() -> None:
         device._connected = True
@@ -33,3 +34,23 @@ async def test_legacy_async_get_connects_before_waiting_for_response() -> None:
     device.async_connect.assert_awaited_once()
     device.async_receive.assert_awaited_once()
     assert device._queue[0].command == Message.GET_COMMAND
+
+
+@pytest.mark.asyncio
+async def test_legacy_async_get_skips_status_request_during_backoff() -> None:
+    """Test legacy GET status refresh does not wait while queue is backing off."""
+    device = TuyaDevice.__new__(TuyaDevice)
+    device.version = (3, 3)
+    device._queue = []
+    device._listeners = {}
+    device._backoff = True
+
+    device.async_connect = AsyncMock()
+    device.async_receive = AsyncMock()
+
+    await device.async_get()
+
+    device.async_connect.assert_not_awaited()
+    device.async_receive.assert_not_awaited()
+    assert device._queue == []
+    assert device._listeners == {}

--- a/tests/test_vacuum/test_vacuum_entity.py
+++ b/tests/test_vacuum/test_vacuum_entity.py
@@ -169,6 +169,93 @@ async def test_update_entity_values(mock_robovac, mock_vacuum_data) -> None:
 
 
 @pytest.mark.asyncio
+async def test_partial_startup_dps_sets_idle(mock_robovac, mock_vacuum_data) -> None:
+    """Test partial startup DPS without status recovers HA from unknown."""
+    mock_robovac._dps = {
+        "151": True,
+        "156": True,
+        "158": "Standard",
+        "159": True,
+        "160": False,
+        "161": 80,
+        "163": 61,
+    }
+    mock_robovac.getDpsCodes.return_value = {
+        "MODE": "152",
+        "STATUS": "173",
+        "RETURN_HOME": "153",
+        "FAN_SPEED": "154",
+        "LOCATE": "153",
+        "BATTERY_LEVEL": "172",
+        "ERROR_CODE": "169",
+    }
+
+    with patch("custom_components.robovac.vacuum.RoboVac", return_value=mock_robovac):
+        entity = RoboVacEntity(mock_vacuum_data)
+
+        entity.update_entity_values()
+
+        assert entity.activity == VacuumActivity.IDLE
+
+
+@pytest.mark.asyncio
+async def test_partial_startup_dps_keeps_explicit_status(
+    mock_robovac, mock_vacuum_data
+) -> None:
+    """Test partial-DPS fallback does not override explicit status."""
+    mock_robovac._dps = {
+        "151": True,
+        "156": True,
+        "158": "Standard",
+        "159": True,
+        "160": False,
+        "161": 80,
+        "163": 61,
+        "173": "Charging",
+    }
+    mock_robovac.getDpsCodes.return_value = {
+        "MODE": "152",
+        "STATUS": "173",
+        "RETURN_HOME": "153",
+        "FAN_SPEED": "154",
+        "LOCATE": "153",
+        "BATTERY_LEVEL": "172",
+        "ERROR_CODE": "169",
+    }
+
+    with patch("custom_components.robovac.vacuum.RoboVac", return_value=mock_robovac):
+        entity = RoboVacEntity(mock_vacuum_data)
+
+        entity.update_entity_values()
+
+        assert entity.tuya_state == "Charging"
+
+
+@pytest.mark.asyncio
+async def test_battery_only_dps_does_not_set_idle(
+    mock_robovac, mock_vacuum_data
+) -> None:
+    """Test battery-only updates are not enough to infer idle."""
+    mock_robovac._dps = {"163": 74}
+    mock_robovac.getDpsCodes.return_value = {
+        "MODE": "152",
+        "STATUS": "173",
+        "RETURN_HOME": "153",
+        "FAN_SPEED": "154",
+        "LOCATE": "153",
+        "BATTERY_LEVEL": "172",
+        "ERROR_CODE": "169",
+    }
+
+    with patch("custom_components.robovac.vacuum.RoboVac", return_value=mock_robovac):
+        entity = RoboVacEntity(mock_vacuum_data)
+
+        entity.update_entity_values()
+
+        assert entity.activity is None
+
+
+@pytest.mark.asyncio
 async def test_fan_speed_formatting(mock_robovac, mock_vacuum_data) -> None:
     """Test fan speed formatting in update_entity_values."""
     # Arrange


### PR DESCRIPTION
  ## Summary
  - Fixes #452 by recovering vacuum state after Home Assistant restart when the local status response contains partial DPS but omits explicit status/mode DPS.
  - Ensures the local GET path connects before waiting for its response, so restart responses update cached DPS reliably.
  - Treats multi-field partial DPS as idle only when no explicit state DPS is present, while avoiding single-field or battery-only inference.

  ## Validation
  - Live-tested on an Eufy X9 Pro / T2320.
  - Verified the restart path recovers the vacuum entity from `unknown` to `idle` after the first partial DPS response.
  - `python -m pytest --cov=custom_components tests --cov-report=xml`
  - `python -m flake8 custom_components tests`
  - `python -m mypy --config-file=pyproject.toml custom_components`