### PR TITLE
fix: preserve original bytes for binary v3.5 payloads

### DIFF
--- a/custom_components/robovac/tuyalocalapi.py
+++ b/custom_components/robovac/tuyalocalapi.py
@@ -793,6 +793,9 @@ class Message:
                 # - 4-byte retcode + 15-byte version header (gratuitous
                 #   updates: retcode + "3.5" + 12 bytes + JSON)
                 # Find the first '{' to locate where JSON starts.
+                # Keep original for binary fallback — the HMAC in SESS_KEY_NEG_RESP
+                # may contain 0x7b ('{'), so we must not strip binary payloads.
+                original_payload_data = payload_data
                 if payload_data and payload_data[0:1] != b"{":
                     json_start = payload_data.find(b"{")
                     if json_start > 0:
@@ -801,8 +804,9 @@ class Message:
                     payload_text = payload_data.decode("utf8")
                     payload = json.loads(payload_text)
                 except (UnicodeDecodeError, json.JSONDecodeError):
-                    # Binary payload (e.g. session key negotiation)
-                    payload = payload_data
+                    # Binary payload (e.g. session key negotiation) — use the
+                    # original unstripped bytes so HMAC fields aren't truncated.
+                    payload = original_payload_data
             except Exception as e:
                 device._LOGGER.debug(f"v3.5 decryption failed: {e}")
                 raise InvalidMessage("GCM decryption/verification failed") from e


### PR DESCRIPTION
- `_from_bytes_v35` searched for `{` (0x7b) to locate JSON in decrypted payloads, truncating everything before it
- The binary fallback path then returned this stripped data instead of the original bytes
- For `SESS_KEY_NEG_RESP`, the 32-byte HMAC can contain 0x7b at any position depending on the random client nonce, causing session negotiation to fail with `payload too short: N bytes` (where N = 52 − position of first `{` in HMAC)
- GCM tag verification still passed, confirming the key was correct — making this hard to diagnose

**Fix:** save `original_payload_data` before the JSON-strip heuristic; use it in the binary fallback so `SESS_KEY_NEG_RESP` and other binary responses arrive intact.