### PR TITLE
ci: update project tooling to Python 3.14

### DIFF
--- a/.github/actions/setup-python-env/action.yml
+++ b/.github/actions/setup-python-env/action.yml
@@ -5,7 +5,7 @@ inputs:
   python-version:
     description: 'Python version to set up'
     required: false
-    default: '3.13'
+    default: '3.14'
   dev-dependencies:
     description: 'Install dev dependencies'
     required: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "robovac"
 version = "2.4.1-beta.1"
 description = "Eufy RoboVac integration for Home Assistant"
 readme = "README.md"
-requires-python = ">=3.13.0"
+requires-python = ">=3.14.2"
 license = {text = "Apache-2.0"}
 authors = [
     {name = "Dan Webb", email = "dan.webb@damacus.io"}
@@ -17,13 +17,13 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Home Automation",
 ]
 
 [tool.black]
 line-length = 88
-target-version = ["py313"]
+target-version = ["py314"]
 include = '\.pyi?$'
 
 [tool.isort]
@@ -31,7 +31,7 @@ profile = "black"
 line_length = 88
 
 [tool.mypy]
-python_version = "3.13"
+python_version = "3.14"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 pytest>=8.0.0
 pytest-asyncio>=0.23.0
 pytest-cov>=4.1.0
-pytest-homeassistant-custom-component>=0.13.233
+pytest-homeassistant-custom-component>=0.13.333
 
 # Code quality tools
 flake8>=7.0.0

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -193,6 +193,10 @@ async def test_user_form_success(
             "custom_components.robovac.config_flow.TuyaAPISession",
             return_value=MagicMock(get_device=MagicMock(return_value=mock_tuya_device)),
         ),
+        patch(
+            "custom_components.robovac.TuyaLocalDiscovery",
+            return_value=MagicMock(start=AsyncMock(), close=MagicMock()),
+        ),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,

--- a/uv.lock
+++ b/uv.lock
@@ -1,8 +1,8 @@
 version = 1
 revision = 3
-requires-python = ">=3.13.0"
+requires-python = ">=3.14.2"
 
 [[package]]
 name = "robovac"
-version = "2.4.0b1"
+version = "2.4.1b1"
 source = { editable = "." }


### PR DESCRIPTION
## Summary

- update project and CI Python target from 3.13 to 3.14
- update mypy/Black Python targets to match Home Assistant 2026.5.x requirements
- require `pytest-homeassistant-custom-component>=0.13.333`, which tracks Home Assistant 2026.5.4
- mock Tuya local discovery in the config-flow success test to avoid real socket attempts under the newer test plugin

## Validation

- `task lint`
- `task type-check`
- `task test` (`557 passed`)