### PR TITLE
fix(T2123): Update T2123 start pause command

### DIFF
--- a/custom_components/robovac/vacuums/T2123.py
+++ b/custom_components/robovac/vacuums/T2123.py
@@ -21,7 +21,8 @@ class T2123(RobovacModelDetails):
     commands = {
         RobovacCommand.START_PAUSE: {
             "code": 2,
-        },
+            "values": {"start": True, "pause": False},
+            },
         RobovacCommand.DIRECTION: {
             "code": 3,
             "values": {


### PR DESCRIPTION
Fixes Start command not working for 25C model (T2123).