### PR TITLE
Start from dock fix and show actual error when present.

### DIFF
--- a/custom_components/robovac/robovac.py
+++ b/custom_components/robovac/robovac.py
@@ -238,6 +238,17 @@ class RoboVac(TuyaDevice):
                     return mapped
                 return str(mapped)
 
+            # Backward-compatible fallback for legacy models where START_PAUSE
+            # exposes only code=2 and omits explicit boolean values.
+            if cmd == RobovacCommand.START_PAUSE:
+                cmd_entry = self.model_details.commands.get(cmd)
+                if isinstance(cmd_entry, dict) and str(cmd_entry.get("code")) == "2":
+                    normalized = str(value).strip().lower()
+                    if normalized == "start":
+                        return True
+                    if normalized in {"pause", "stop"}:
+                        return False
+
         except (ValueError, KeyError):
             pass
 

--- a/custom_components/robovac/vacuum.py
+++ b/custom_components/robovac/vacuum.py
@@ -505,6 +505,24 @@ class RoboVacEntity(StateVacuumEntity):
             )
             return VacuumActivity.CLEANING
 
+    @property
+    def state(self) -> str | None:
+        """Return state text for Home Assistant cards.
+
+        When an explicit device error is present, expose the detailed error
+        message instead of the generic "Error" label.
+        """
+        if self.activity == VacuumActivity.ERROR:
+            if self._attr_error_code is not None and self._attr_error_code not in [
+                0,
+                "no_error",
+                "No error",
+            ]:
+                detailed_error = getErrorMessage(self._attr_error_code)
+                if detailed_error and str(detailed_error).strip():
+                    return str(detailed_error)
+        return super().state
+
     def _return_progress_activity(self) -> VacuumActivity | None:
         """Return activity from models that expose return/dock progress on RETURN_HOME DPS."""
         if self.tuyastatus is None or self.vacuum is None:
@@ -1007,7 +1025,7 @@ class RoboVacEntity(StateVacuumEntity):
             if self.fan_speed == "No_suction":
                 self._attr_fan_speed = "No Suction"
             elif self.fan_speed == "Boost_IQ":
-                self._attr_fan_speed = "Boost IQ"
+                self._attr_fan_speed = "Boost Iq"
             elif self.fan_speed == "Quiet":
                 self._attr_fan_speed = (
                     "Pure" if "Pure" in self._attr_fan_speed_list else "Quiet"
@@ -1280,12 +1298,29 @@ class RoboVacEntity(StateVacuumEntity):
             _LOGGER.error("Cannot start vacuum: vacuum not initialized")
             return
 
+        if self.model_code and str(self.model_code).startswith("T2253"):
+            await self.vacuum.async_set({
+                "122": "Continue",
+                self.get_dps_code("MODE"): self.vacuum.getRoboVacCommandValue(
+                    RobovacCommand.MODE,
+                    "auto"
+                ),
+            })
+            return
+
         payload: dict[str, Any] = {
-            self.get_dps_code("MODE"): self.vacuum.getRoboVacCommandValue(RobovacCommand.MODE, "auto")
+            self.get_dps_code("MODE"): self.vacuum.getRoboVacCommandValue(
+                RobovacCommand.MODE,
+                "auto"
+            )
         }
 
         # For models with boolean START_PAUSE (e.g. T2118, T2128), also toggle start
-        start_value = self.vacuum.getRoboVacCommandValue(RobovacCommand.START_PAUSE, "start")
+        start_value = self.vacuum.getRoboVacCommandValue(
+            RobovacCommand.START_PAUSE,
+            "start"
+        )
+
         if start_value != "start":
             payload[self.get_dps_code("START_PAUSE")] = start_value
 
@@ -1317,6 +1352,11 @@ class RoboVacEntity(StateVacuumEntity):
         Args:
             **kwargs: Additional arguments passed from Home Assistant.
         """
+        
+        if self.vacuum is None:
+            _LOGGER.error("Cannot stop vacuum: vacuum not initialized")
+            return
+
         await self.async_return_to_base()
 
     async def async_clean_spot(self, **kwargs: Any) -> None:

--- a/custom_components/robovac/vacuum.py
+++ b/custom_components/robovac/vacuum.py
@@ -216,6 +216,19 @@ class RoboVacEntity(StateVacuumEntity):
     _attr_room_names: dict[str, dict[str, Any]] | None = None
     _attr_room_map_id: int | None = None
 
+    _LEGACY_CONTINUE_MODELS = (
+        "T2250",
+        "T2251",
+        "T2252",
+        "T2253",
+        "T2254",
+        "T2255",
+        "T2259",
+        "T2261",
+        "T2262",
+        "T2273",
+    )
+
     @property
     def robovac_supported(self) -> int | None:
         """Return the supported features of the vacuum cleaner."""
@@ -1140,6 +1153,26 @@ class RoboVacEntity(StateVacuumEntity):
         except Exception as ex:
             _LOGGER.debug("T2320 room metadata decode failed for %s: %s", self.name, ex)
 
+    def _uses_legacy_continue_workaround(self) -> bool:
+        """Return True for legacy simple-auto models that need DP122 Continue."""
+        return bool(self.model_code and str(self.model_code).startswith(self._LEGACY_CONTINUE_MODELS))
+
+    def _has_explicit_start_pause_values(self) -> bool:
+        """Return True when the model defines explicit START_PAUSE values."""
+        if self.vacuum is None:
+            return False
+
+        start_pause = getattr(self.vacuum.model_details, "commands", {}).get(RobovacCommand.START_PAUSE)
+        return isinstance(start_pause, dict) and isinstance(start_pause.get("values"), dict)
+
+    def _is_legacy_paused_state(self) -> bool:
+        """Return True when a legacy model reports the paused state via DP122."""
+        if not self._uses_legacy_continue_workaround() or self.tuyastatus is None:
+            return False
+
+        raw_continue_state = self.tuyastatus.get("122")
+        return isinstance(raw_continue_state, str) and raw_continue_state.casefold() == "pause"
+
     def _build_tuya_session_sync(self) -> TuyaAPISession | None:
         """Authenticate to Tuya cloud using stored Eufy credentials."""
         if not self._eufy_username or not self._eufy_password:
@@ -1277,6 +1310,9 @@ class RoboVacEntity(StateVacuumEntity):
             _LOGGER.error("Cannot return to base: vacuum not initialized")
             return
 
+        if self._is_legacy_paused_state():
+            await self.vacuum.async_set({"122": "Continue"})
+
         payload: dict[str, Any] = {
             self.get_dps_code("RETURN_HOME"): self.vacuum.getRoboVacCommandValue(RobovacCommand.RETURN_HOME, "return")
         }
@@ -1298,7 +1334,7 @@ class RoboVacEntity(StateVacuumEntity):
             _LOGGER.error("Cannot start vacuum: vacuum not initialized")
             return
 
-        if self.model_code and str(self.model_code).startswith("T2253"):
+        if self._uses_legacy_continue_workaround() and not self._has_explicit_start_pause_values():
             await self.vacuum.async_set({
                 "122": "Continue",
                 self.get_dps_code("MODE"): self.vacuum.getRoboVacCommandValue(
@@ -1314,6 +1350,9 @@ class RoboVacEntity(StateVacuumEntity):
                 "auto"
             )
         }
+
+        if self._uses_legacy_continue_workaround():
+            payload["122"] = "Continue"
 
         # For models with boolean START_PAUSE (e.g. T2118, T2128), also toggle start
         start_value = self.vacuum.getRoboVacCommandValue(

--- a/tests/test_vacuum/test_get_robovac_command_value.py
+++ b/tests/test_vacuum/test_get_robovac_command_value.py
@@ -78,3 +78,25 @@ def test_get_robovac_command_value_error_handling(mock_robovac):
 
     # Should return the original value when an exception occurs
     assert mock_robovac.getRoboVacCommandValue(RobovacCommand.MODE, "auto") == "auto"
+
+
+def test_get_robovac_command_value_start_pause_legacy_fallback(mock_robovac):
+    """Legacy START_PAUSE code=2 without values falls back to bool toggle."""
+    mock_robovac.model_details.commands[RobovacCommand.START_PAUSE] = {
+        "code": 2,
+    }
+
+    assert mock_robovac.getRoboVacCommandValue(RobovacCommand.START_PAUSE, "start") is True
+    assert mock_robovac.getRoboVacCommandValue(RobovacCommand.START_PAUSE, "pause") is False
+
+
+def test_get_robovac_command_value_no_values_non_start_pause_unchanged(mock_robovac):
+    """No-values fallback should not affect non-START_PAUSE commands."""
+    mock_robovac.model_details.commands[RobovacCommand.RETURN_HOME] = {
+        "code": 101,
+    }
+
+    assert (
+        mock_robovac.getRoboVacCommandValue(RobovacCommand.RETURN_HOME, "return")
+        == "return"
+    )

--- a/tests/test_vacuum/test_vacuum_commands.py
+++ b/tests/test_vacuum/test_vacuum_commands.py
@@ -65,6 +65,35 @@ async def test_async_return_to_base(mock_robovac, mock_vacuum_data) -> None:
 
 
 @pytest.mark.asyncio
+async def test_async_return_to_base_resumes_then_returns_when_paused_for_legacy_models(
+    mock_vacuum_data,
+) -> None:
+    """Test paused legacy models resume before return-to-dock."""
+    data = dict(mock_vacuum_data)
+    data[CONF_MODEL] = "T2273"
+
+    with patch("custom_components.robovac.robovac.TuyaDevice.__init__", return_value=None):
+        robovac = RoboVac(
+            model_code="T2273",
+            device_id="test_id",
+            host="192.168.1.100",
+            local_key="test_key",
+        )
+    robovac.async_set = AsyncMock(return_value=True)
+
+    with patch("custom_components.robovac.vacuum.RoboVac", return_value=robovac):
+        entity = RoboVacEntity(data)
+        entity.tuyastatus = {"122": "Pause"}
+
+        await entity.async_return_to_base()
+
+        assert robovac.async_set.call_args_list == [
+            call({"122": "Continue"}),
+            call({"101": "return"}),
+        ]
+
+
+@pytest.mark.asyncio
 async def test_async_start(mock_robovac, mock_vacuum_data) -> None:
     """Test the async_start method."""
     # Arrange
@@ -98,6 +127,54 @@ async def test_async_start_model_specific(mock_robovac, mock_vacuum_data: Any, m
         # Now that we've updated the implementation, L60 should send base64 value "BBoCCAE="
         # instead of "auto" for the MODE command
         mock_l60.async_set.assert_called_once_with({"152": "BBoCCAE="})
+
+
+@pytest.mark.asyncio
+async def test_async_start_sends_continue_for_t2273(
+    mock_vacuum_data,
+) -> None:
+    """Test async_start sends DP122 Continue for T2273 legacy models."""
+    data = dict(mock_vacuum_data)
+    data[CONF_MODEL] = "T2273"
+
+    with patch("custom_components.robovac.robovac.TuyaDevice.__init__", return_value=None):
+        robovac = RoboVac(
+            model_code="T2273",
+            device_id="test_id",
+            host="192.168.1.100",
+            local_key="test_key",
+        )
+    robovac.async_set = AsyncMock(return_value=True)
+
+    with patch("custom_components.robovac.vacuum.RoboVac", return_value=robovac):
+        entity = RoboVacEntity(data)
+        await entity.async_start()
+
+        robovac.async_set.assert_called_once_with({"122": "Continue", "5": "Auto"})
+
+
+@pytest.mark.asyncio
+async def test_async_start_adds_continue_for_boolean_start_pause_models(
+    mock_vacuum_data,
+) -> None:
+    """Test async_start keeps START_PAUSE and adds DP122 Continue for legacy boolean models."""
+    data = dict(mock_vacuum_data)
+    data[CONF_MODEL] = "T2262"
+
+    with patch("custom_components.robovac.robovac.TuyaDevice.__init__", return_value=None):
+        robovac = RoboVac(
+            model_code="T2262",
+            device_id="test_id",
+            host="192.168.1.100",
+            local_key="test_key",
+        )
+    robovac.async_set = AsyncMock(return_value=True)
+
+    with patch("custom_components.robovac.vacuum.RoboVac", return_value=robovac):
+        entity = RoboVacEntity(data)
+        await entity.async_start()
+
+        robovac.async_set.assert_called_once_with({"122": "Continue", "5": "Auto", "2": True})
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fix on v2.4.3-beta.1

I have made a fix for vacuums that could not start when docked and a custom fix for T2253 (G30 hybrid) because it could not start again after being paused. Maybe the custom fix can be used on other/ all models.

Aditionally i changed the text Error with the actual error when present it is present.

+ Show Boost Iq in the Fan speed button when selected because it was missing.


If you run v2.4.3-beta.1, then until this hopefully gets merged you can copy the code of the two changed files. Remember to backup.