### PR TITLE
fix: restore legacy robovac commands

### DIFF
--- a/custom_components/robovac/vacuums/T1250.py
+++ b/custom_components/robovac/vacuums/T1250.py
@@ -24,6 +24,7 @@ class T1250(RobovacModelDetails):
     commands = {
         RobovacCommand.START_PAUSE: {
             "code": 2,
+            "values": {"start": True, "pause": False},
         },
         RobovacCommand.DIRECTION: {
             "code": 3,

--- a/custom_components/robovac/vacuums/T2080.py
+++ b/custom_components/robovac/vacuums/T2080.py
@@ -35,6 +35,7 @@ class T2080(RobovacModelDetails):
             "code": 2,
             # I've seen `'2': False` when ending a session (maybe when paused??)
             # I've also seen `'2': False` when actively vacuuming..
+            "values": {"start": True, "pause": False},
         },
         RobovacCommand.DIRECTION: {
             # Not working

--- a/custom_components/robovac/vacuums/T2103.py
+++ b/custom_components/robovac/vacuums/T2103.py
@@ -19,6 +19,7 @@ class T2103(RobovacModelDetails):
     commands = {
         RobovacCommand.START_PAUSE: {
             "code": 2,
+            "values": {"start": True, "pause": False},
         },
         RobovacCommand.DIRECTION: {
             "code": 3,

--- a/custom_components/robovac/vacuums/T2117.py
+++ b/custom_components/robovac/vacuums/T2117.py
@@ -21,6 +21,7 @@ class T2117(RobovacModelDetails):
     commands = {
         RobovacCommand.START_PAUSE: {
             "code": 2,
+            "values": {"start": True, "pause": False},
         },
         RobovacCommand.DIRECTION: {
             "code": 3,

--- a/custom_components/robovac/vacuums/T2118.py
+++ b/custom_components/robovac/vacuums/T2118.py
@@ -49,6 +49,7 @@ class T2118(RobovacModelDetails):
                 "completed": "Completed",
                 "Running": "Running",
                 "standby": "Standby",
+                "Recharge": "Returning to Dock",
                 "Sleeping": "Sleeping",
                 "recharge_needed": "Recharge needed",
             },

--- a/custom_components/robovac/vacuums/T2119.py
+++ b/custom_components/robovac/vacuums/T2119.py
@@ -21,6 +21,7 @@ class T2119(RobovacModelDetails):
     commands = {
         RobovacCommand.START_PAUSE: {
             "code": 2,
+            "values": {"start": True, "pause": False},
         },
         RobovacCommand.DIRECTION: {
             "code": 3,

--- a/custom_components/robovac/vacuums/T2120.py
+++ b/custom_components/robovac/vacuums/T2120.py
@@ -21,6 +21,7 @@ class T2120(RobovacModelDetails):
     commands = {
         RobovacCommand.START_PAUSE: {
             "code": 2,
+            "values": {"start": True, "pause": False},
         },
         RobovacCommand.DIRECTION: {
             "code": 3,

--- a/custom_components/robovac/vacuums/T2123.py
+++ b/custom_components/robovac/vacuums/T2123.py
@@ -21,6 +21,7 @@ class T2123(RobovacModelDetails):
     commands = {
         RobovacCommand.START_PAUSE: {
             "code": 2,
+            "values": {"start": True, "pause": False},
         },
         RobovacCommand.DIRECTION: {
             "code": 3,

--- a/custom_components/robovac/vacuums/T2130.py
+++ b/custom_components/robovac/vacuums/T2130.py
@@ -19,6 +19,7 @@ class T2130(RobovacModelDetails):
     commands = {
         RobovacCommand.START_PAUSE: {
             "code": 2,
+            "values": {"start": True, "pause": False},
         },
         RobovacCommand.DIRECTION: {
             "code": 3,

--- a/custom_components/robovac/vacuums/T2132.py
+++ b/custom_components/robovac/vacuums/T2132.py
@@ -22,6 +22,7 @@ class T2132(RobovacModelDetails):
     commands = {
         RobovacCommand.START_PAUSE: {
             "code": 2,
+            "values": {"start": True, "pause": False},
         },
         RobovacCommand.DIRECTION: {
             "code": 3,

--- a/custom_components/robovac/vacuums/T2150.py
+++ b/custom_components/robovac/vacuums/T2150.py
@@ -24,6 +24,7 @@ class T2150(RobovacModelDetails):
     commands = {
         RobovacCommand.START_PAUSE: {
             "code": 2,
+            "values": {"start": True, "pause": False},
         },
         RobovacCommand.DIRECTION: {
             "code": 3,

--- a/custom_components/robovac/vacuums/T2190.py
+++ b/custom_components/robovac/vacuums/T2190.py
@@ -30,6 +30,7 @@ class T2190(RobovacModelDetails):
     commands = {
         RobovacCommand.START_PAUSE: {
             "code": 2,
+            "values": {"start": True, "pause": False},
         },
         RobovacCommand.DIRECTION: {
             "code": 3,

--- a/custom_components/robovac/vacuums/T2192.py
+++ b/custom_components/robovac/vacuums/T2192.py
@@ -29,6 +29,7 @@ class T2192(RobovacModelDetails):
     commands = {
         RobovacCommand.START_PAUSE: {
             "code": 2,
+            "values": {"start": True, "pause": False},
         },
         RobovacCommand.DIRECTION: {
             "code": 3,

--- a/custom_components/robovac/vacuums/T2210.py
+++ b/custom_components/robovac/vacuums/T2210.py
@@ -24,6 +24,7 @@ class T2210(RobovacModelDetails):
     commands = {
         RobovacCommand.START_PAUSE: {
             "code": 2,
+            "values": {"start": True, "pause": False},
         },
         RobovacCommand.DIRECTION: {
             "code": 3,

--- a/custom_components/robovac/vacuums/T2212.py
+++ b/custom_components/robovac/vacuums/T2212.py
@@ -24,6 +24,7 @@ class T2212(RobovacModelDetails):
     commands = {
         RobovacCommand.START_PAUSE: {
             "code": 2,
+            "values": {"start": True, "pause": False},
         },
         RobovacCommand.DIRECTION: {
             "code": 3,

--- a/custom_components/robovac/vacuums/T2250.py
+++ b/custom_components/robovac/vacuums/T2250.py
@@ -24,6 +24,7 @@ class T2250(RobovacModelDetails):
     commands = {
         RobovacCommand.START_PAUSE: {
             "code": 2,
+            "values": {"start": True, "pause": False},
         },
         RobovacCommand.DIRECTION: {
             "code": 3,

--- a/custom_components/robovac/vacuums/T2251.py
+++ b/custom_components/robovac/vacuums/T2251.py
@@ -24,6 +24,7 @@ class T2251(RobovacModelDetails):
     commands = {
         RobovacCommand.START_PAUSE: {
             "code": 2,
+            "values": {"start": True, "pause": False},
         },
         RobovacCommand.DIRECTION: {
             "code": 3,
@@ -51,6 +52,7 @@ class T2251(RobovacModelDetails):
                 "completed": "Completed",
                 "Running": "Running",
                 "standby": "Standby",
+                "Recharge": "Returning to Dock",
                 "Sleeping": "Sleeping",
                 "recharge_needed": "Recharge needed",
             },

--- a/custom_components/robovac/vacuums/T2252.py
+++ b/custom_components/robovac/vacuums/T2252.py
@@ -52,6 +52,7 @@ class T2252(RobovacModelDetails):
                 "completed": "Completed",
                 "Running": "Running",
                 "standby": "Standby",
+                "Recharge": "Returning to Dock",
                 "Sleeping": "Sleeping",
                 "recharge_needed": "Recharge needed",
             },

--- a/custom_components/robovac/vacuums/T2253.py
+++ b/custom_components/robovac/vacuums/T2253.py
@@ -27,6 +27,7 @@ class T2253(RobovacModelDetails):
     commands = {
         RobovacCommand.START_PAUSE: {
             "code": 2,
+            "values": {"start": True, "pause": False},
         },
         RobovacCommand.DIRECTION: {
             "code": 3,

--- a/custom_components/robovac/vacuums/T2254.py
+++ b/custom_components/robovac/vacuums/T2254.py
@@ -24,6 +24,7 @@ class T2254(RobovacModelDetails):
     commands = {
         RobovacCommand.START_PAUSE: {
             "code": 2,
+            "values": {"start": True, "pause": False},
         },
         RobovacCommand.DIRECTION: {
             "code": 3,

--- a/custom_components/robovac/vacuums/T2255.py
+++ b/custom_components/robovac/vacuums/T2255.py
@@ -24,6 +24,7 @@ class T2255(RobovacModelDetails):
     commands = {
         RobovacCommand.START_PAUSE: {
             "code": 2,
+            "values": {"start": True, "pause": False},
         },
         RobovacCommand.DIRECTION: {
             "code": 3,

--- a/custom_components/robovac/vacuums/T2259.py
+++ b/custom_components/robovac/vacuums/T2259.py
@@ -24,6 +24,7 @@ class T2259(RobovacModelDetails):
     commands = {
         RobovacCommand.START_PAUSE: {
             "code": 2,
+            "values": {"start": True, "pause": False},
         },
         RobovacCommand.DIRECTION: {
             "code": 3,

--- a/custom_components/robovac/vacuums/T2262.py
+++ b/custom_components/robovac/vacuums/T2262.py
@@ -28,6 +28,7 @@ class T2262(RobovacModelDetails):
     commands = {
         RobovacCommand.START_PAUSE: {
             "code": 2,
+            "values": {"start": True, "pause": False},
         },
         RobovacCommand.DIRECTION: {
             "code": 3,
@@ -55,6 +56,7 @@ class T2262(RobovacModelDetails):
                 "completed": "Completed",
                 "Running": "Running",
                 "standby": "Standby",
+                "Recharge": "Returning to Dock",
                 "Sleeping": "Sleeping",
                 "recharge_needed": "Recharge needed",
             },

--- a/custom_components/robovac/vacuums/T2268.py
+++ b/custom_components/robovac/vacuums/T2268.py
@@ -28,6 +28,7 @@ class T2268(RobovacModelDetails):
     commands = {
         RobovacCommand.START_PAUSE: {
             "code": 2,
+            "values": {"start": True, "pause": False},
         },
         RobovacCommand.DIRECTION: {
             "code": 3,

--- a/custom_components/robovac/vacuums/T2270.py
+++ b/custom_components/robovac/vacuums/T2270.py
@@ -21,7 +21,10 @@ class T2270(RobovacModelDetails):
         | RoboVacEntityFeature.AUTO_RETURN
     )
     commands = {
-        RobovacCommand.START_PAUSE: 2,
+        RobovacCommand.START_PAUSE: {
+            "code": 2,
+            "values": {"start": True, "pause": False},
+        },
         RobovacCommand.DIRECTION: {
             "code": 3,
             "values": {

--- a/custom_components/robovac/vacuums/T2272.py
+++ b/custom_components/robovac/vacuums/T2272.py
@@ -23,6 +23,7 @@ class T2272(RobovacModelDetails):
     commands = {
         RobovacCommand.START_PAUSE: {
             "code": 2,
+            "values": {"start": True, "pause": False},
         },
         RobovacCommand.DIRECTION: {
             "code": 3,

--- a/custom_components/robovac/vacuums/T2273.py
+++ b/custom_components/robovac/vacuums/T2273.py
@@ -24,6 +24,7 @@ class T2273(RobovacModelDetails):
     commands = {
         RobovacCommand.START_PAUSE: {
             "code": 2,
+            "values": {"start": True, "pause": False},
         },
         RobovacCommand.DIRECTION: {
             "code": 3,

--- a/tests/test_vacuum/test_get_robovac_command_value.py
+++ b/tests/test_vacuum/test_get_robovac_command_value.py
@@ -18,7 +18,7 @@ def mock_robovac():
         )
 
         # Mock the model commands for testing
-        robovac.model_details.commands = {
+        commands = {
             RobovacCommand.MODE: {
                 "code": 5,
                 "values": {
@@ -36,7 +36,8 @@ def mock_robovac():
                 "code": 102,
             },
         }
-        return robovac
+        with patch.object(robovac.model_details, "commands", commands):
+            yield robovac
 
 
 def test_get_robovac_command_value_with_dict(mock_robovac):

--- a/tests/test_vacuum/test_get_robovac_human_readable_value.py
+++ b/tests/test_vacuum/test_get_robovac_human_readable_value.py
@@ -20,7 +20,7 @@ def mock_t2080_robovac() -> RoboVac:
         )
 
         # Mock the T2080 model commands for testing
-        robovac.model_details.commands = {
+        commands = {
             RobovacCommand.STATUS: {
                 "code": 153,
                 "values": {
@@ -59,7 +59,8 @@ def mock_t2080_robovac() -> RoboVac:
                 },
             },
         }
-        return robovac
+        with patch.object(robovac.model_details, "commands", commands):
+            yield robovac
 
 
 def test_get_human_readable_value_status_success(mock_t2080_robovac) -> None:

--- a/tests/test_vacuum/test_legacy_start_pause_mappings.py
+++ b/tests/test_vacuum/test_legacy_start_pause_mappings.py
@@ -1,0 +1,118 @@
+"""Regression tests for legacy DPS 2 start/pause command mappings."""
+
+from importlib import import_module
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+
+LEGACY_DPS2_MODELS = (
+    "T1250",
+    "T2080",
+    "T2103",
+    "T2117",
+    "T2118",
+    "T2119",
+    "T2120",
+    "T2123",
+    "T2128",
+    "T2130",
+    "T2132",
+    "T2150",
+    "T2181",
+    "T2190",
+    "T2192",
+    "T2193",
+    "T2194",
+    "T2210",
+    "T2212",
+    "T2250",
+    "T2251",
+    "T2252",
+    "T2253",
+    "T2254",
+    "T2255",
+    "T2259",
+    "T2261",
+    "T2262",
+    "T2268",
+    "T2270",
+    "T2272",
+    "T2273",
+    "T2276",
+    "T2320",
+    "T2351",
+)
+
+
+def _robovac_context() -> tuple[Any, Any, Any]:
+    """Return current robovac modules after tests that reload them."""
+    robovac_module = import_module("custom_components.robovac.robovac")
+    vacuums_module = import_module("custom_components.robovac.vacuums")
+    base_module = import_module("custom_components.robovac.vacuums.base")
+    return robovac_module.RoboVac, vacuums_module.ROBOVAC_MODELS, base_module.RobovacCommand
+
+
+@pytest.mark.parametrize("model_code", LEGACY_DPS2_MODELS)
+def test_legacy_dps2_start_pause_maps_to_booleans(model_code: str) -> None:
+    """Legacy DPS 2 start/pause controls must send booleans, not strings."""
+    robo_vac, _, robovac_command = _robovac_context()
+
+    with patch("custom_components.robovac.robovac.TuyaDevice.__init__", return_value=None):
+        robovac = robo_vac(
+            model_code=model_code,
+            device_id="test_id",
+            host="192.168.1.100",
+            local_key="test_key",
+        )
+
+    assert robovac.getRoboVacCommandValue(robovac_command.START_PAUSE, "start") is True
+    assert robovac.getRoboVacCommandValue(robovac_command.START_PAUSE, "pause") is False
+
+
+def _command_code(command: Any) -> str | None:
+    """Return the command DPS code as a string."""
+    if isinstance(command, dict) and "code" in command:
+        return str(command["code"])
+    if not isinstance(command, dict):
+        return str(command)
+    return None
+
+
+def test_no_model_has_bare_dps2_start_pause_mapping() -> None:
+    """Guard against DPS 2 models omitting explicit boolean start/pause values."""
+    _, robovac_models, robovac_command = _robovac_context()
+    bare_models = []
+
+    for model_code, model_details in robovac_models.items():
+        command = model_details.commands.get(robovac_command.START_PAUSE)
+        if _command_code(command) != "2":
+            continue
+
+        values = command.get("values") if isinstance(command, dict) else None
+        if not isinstance(values, dict) or values.get("start") is not True or values.get("pause") is not False:
+            bare_models.append(model_code)
+
+    assert bare_models == []
+
+
+def test_legacy_status_maps_recharge_value() -> None:
+    """Guard legacy status maps against missing Recharge values."""
+    _, robovac_models, robovac_command = _robovac_context()
+    missing_recharge = []
+    legacy_status_values = {"Charging", "completed", "Running", "standby"}
+
+    for model_code, model_details in robovac_models.items():
+        command = model_details.commands.get(robovac_command.STATUS)
+        if not isinstance(command, dict) or _command_code(command) != "15":
+            continue
+
+        values = command.get("values")
+        if not isinstance(values, dict) or not legacy_status_values <= set(values):
+            continue
+
+        if values.get("Recharge") != "Returning to Dock":
+            missing_recharge.append(model_code)
+
+    assert missing_recharge == []

--- a/tests/test_vacuum/test_t2118_command_mappings.py
+++ b/tests/test_vacuum/test_t2118_command_mappings.py
@@ -49,6 +49,7 @@ def test_t2118_status_human_readable(mock_t2118_robovac) -> None:
     assert mock_t2118_robovac.getRoboVacHumanReadableValue(RobovacCommand.STATUS, "Charging") == "Charging"
     assert mock_t2118_robovac.getRoboVacHumanReadableValue(RobovacCommand.STATUS, "Running") == "Running"
     assert mock_t2118_robovac.getRoboVacHumanReadableValue(RobovacCommand.STATUS, "standby") == "Standby"
+    assert mock_t2118_robovac.getRoboVacHumanReadableValue(RobovacCommand.STATUS, "Recharge") == "Returning to Dock"
     assert mock_t2118_robovac.getRoboVacHumanReadableValue(RobovacCommand.STATUS, "Sleeping") == "Sleeping"
     assert mock_t2118_robovac.getRoboVacHumanReadableValue(RobovacCommand.STATUS, "recharge_needed") == "Recharge needed"
 

--- a/tests/test_vacuum/test_t2251_command_mappings.py
+++ b/tests/test_vacuum/test_t2251_command_mappings.py
@@ -62,6 +62,18 @@ def test_t2251_status_human_readable(mock_t2251_robovac) -> None:
     assert mock_t2251_robovac.getRoboVacHumanReadableValue(RobovacCommand.STATUS, "standby") == "Standby"
     assert mock_t2251_robovac.getRoboVacHumanReadableValue(RobovacCommand.STATUS, "Sleeping") == "Sleeping"
     assert mock_t2251_robovac.getRoboVacHumanReadableValue(RobovacCommand.STATUS, "recharge_needed") == "Recharge needed"
+    assert mock_t2251_robovac.getRoboVacHumanReadableValue(RobovacCommand.STATUS, "Recharge") == "Returning to Dock"
+
+
+def test_t2251_start_pause_values(mock_t2251_robovac) -> None:
+    """Test T2251 START_PAUSE maps 'start' to True and 'pause' to False.
+
+    G30 Edge reports the same legacy DPS 2 boolean start/pause behavior as
+    related G30 models. Without this mapping, HA omits DPS 2 on start and
+    sends the string "pause" on pause.
+    """
+    assert mock_t2251_robovac.getRoboVacCommandValue(RobovacCommand.START_PAUSE, "start") is True
+    assert mock_t2251_robovac.getRoboVacCommandValue(RobovacCommand.START_PAUSE, "pause") is False
 
 
 def test_t2251_error_code_mapping(mock_t2251_robovac) -> None:

--- a/tests/test_vacuum/test_t2252_command_mappings.py
+++ b/tests/test_vacuum/test_t2252_command_mappings.py
@@ -65,6 +65,7 @@ def test_t2252_status_human_readable(mock_t2252_robovac) -> None:
     assert mock_t2252_robovac.getRoboVacHumanReadableValue(RobovacCommand.STATUS, "completed") == "Completed"
     assert mock_t2252_robovac.getRoboVacHumanReadableValue(RobovacCommand.STATUS, "Running") == "Running"
     assert mock_t2252_robovac.getRoboVacHumanReadableValue(RobovacCommand.STATUS, "standby") == "Standby"
+    assert mock_t2252_robovac.getRoboVacHumanReadableValue(RobovacCommand.STATUS, "Recharge") == "Returning to Dock"
     assert mock_t2252_robovac.getRoboVacHumanReadableValue(RobovacCommand.STATUS, "Sleeping") == "Sleeping"
     assert mock_t2252_robovac.getRoboVacHumanReadableValue(RobovacCommand.STATUS, "recharge_needed") == "Recharge needed"
 

--- a/tests/test_vacuum/test_t2262_command_mappings.py
+++ b/tests/test_vacuum/test_t2262_command_mappings.py
@@ -59,6 +59,7 @@ def test_t2262_status_human_readable(mock_t2262_robovac) -> None:
     assert mock_t2262_robovac.getRoboVacHumanReadableValue(RobovacCommand.STATUS, "completed") == "Completed"
     assert mock_t2262_robovac.getRoboVacHumanReadableValue(RobovacCommand.STATUS, "Running") == "Running"
     assert mock_t2262_robovac.getRoboVacHumanReadableValue(RobovacCommand.STATUS, "standby") == "Standby"
+    assert mock_t2262_robovac.getRoboVacHumanReadableValue(RobovacCommand.STATUS, "Recharge") == "Returning to Dock"
     assert mock_t2262_robovac.getRoboVacHumanReadableValue(RobovacCommand.STATUS, "Sleeping") == "Sleeping"
     assert mock_t2262_robovac.getRoboVacHumanReadableValue(RobovacCommand.STATUS, "recharge_needed") == "Recharge needed"
 


### PR DESCRIPTION
## Summary
- add explicit boolean start/pause mappings for legacy DPS 2 models so Home Assistant sends start/pause payloads again
- map the observed Recharge status for T2251 and sibling legacy status models T2118, T2252, and T2262
- add regression guards for bare DPS 2 mappings and missing Recharge status values

## Verification
- ./\.venv/bin/pytest tests/test_vacuum/test_legacy_start_pause_mappings.py tests/test_vacuum/test_t2118_command_mappings.py tests/test_vacuum/test_t2251_command_mappings.py tests/test_vacuum/test_t2252_command_mappings.py tests/test_vacuum/test_t2262_command_mappings.py -q
- task test
- task type-check
- task lint

## Notes
- RETURN_HOME and DP122 behavior are intentionally unchanged; those need separate hardware validation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/robovac/pull/515" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->