### PR TITLE
test: add mutation testing

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,0 +1,34 @@
+name: Mutation Testing
+
+on:
+  workflow_dispatch:
+
+jobs:
+  mutation:
+    runs-on: ubuntu-latest
+    name: runner / mutation
+    steps:
+      - name: Check out code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Setup Python Environment
+        uses: ./.github/actions/setup-python-env
+        with:
+          dev-dependencies: true
+
+      - name: Run mutmut
+        continue-on-error: true
+        run: task mutation:code
+
+      - name: Run mapping mutation audit
+        run: task mutation:mappings
+
+      - name: Upload mutation reports
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: mutation-reports
+          if-no-files-found: ignore
+          path: |
+            mutation-reports/
+            mutants/

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ htmlcov/
 .pytest_cache/
 coverage.xml
 .mypy_cache
+mutants/
+mutation-reports/
 __pycache__/
 
 # IDE specific files

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -24,16 +24,37 @@ tasks:
     cmds:
       - uv run pytest --cov=custom_components tests --cov-report=xml
 
+  mutation:
+    desc: Run advisory mutation testing
+    cmds:
+      - task: mutation:code
+      - task: mutation:mappings
+
+  mutation:code:
+    desc: Run mutmut against executable RoboVac code
+    cmds:
+      - uv run mutmut run {{.CLI_ARGS}}
+
+  mutation:browse:
+    desc: Browse mutmut survivors
+    cmds:
+      - uv run mutmut browse
+
+  mutation:mappings:
+    desc: Run RoboVac model mapping mutation audit
+    cmds:
+      - uv run python scripts/mutate_model_mappings.py {{.CLI_ARGS}}
+
   install-dev:
     desc: Install development dependencies
     cmds:
-      - uv venv
+      - uv venv --allow-existing
       - uv pip install -r requirements-dev.txt
 
   install:
     desc: Install dependencies
     cmds:
-      - uv venv
+      - uv venv --allow-existing
       - uv pip install -r requirements.txt
 
   type-check:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,3 +82,28 @@ exclude_lines = [
     "pass",
     "raise ImportError",
 ]
+
+[tool.mutmut]
+source_paths = ["custom_components/robovac"]
+# mutmut 3 supports only_mutate; the old paths_to_mutate key was renamed to source_paths.
+only_mutate = [
+    "custom_components/robovac/robovac.py",
+    "custom_components/robovac/vacuum.py",
+    "custom_components/robovac/sensor.py",
+    "custom_components/robovac/select.py",
+    "custom_components/robovac/switch.py",
+    "custom_components/robovac/proto_decode.py",
+    "custom_components/robovac/case_insensitive_lookup.py",
+    "custom_components/robovac/model_validator.py",
+    "custom_components/robovac/vacuums/*",
+]
+pytest_add_cli_args_test_selection = [
+    "tests/test_case_insensitive_lookup.py",
+    "tests/test_model_validator.py",
+    "tests/test_vacuum",
+    "--ignore=tests/test_vacuum/test_protocol_35_cipher.py",
+    "--ignore=tests/test_vacuum/test_protocol_35_message.py",
+]
+mutate_only_covered_lines = true
+max_stack_depth = 8
+timeout_multiplier = 10.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@ pytest>=8.0.0
 pytest-asyncio>=0.23.0
 pytest-cov>=4.1.0
 pytest-homeassistant-custom-component>=0.13.333
+mutmut>=3.6.0
 
 # Code quality tools
 flake8>=7.0.0

--- a/scripts/mutate_model_mappings.py
+++ b/scripts/mutate_model_mappings.py
@@ -1,0 +1,625 @@
+#!/usr/bin/env python3
+"""Run domain-specific mutation checks for RoboVac model mappings.
+
+The script copies the source tree to a temporary directory, applies one mapping
+mutation at a time, and runs the relevant tests against the mutated copy. It
+does not modify the working tree.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODEL_DIR = Path("custom_components/robovac/vacuums")
+VACUUM_ENTITY = Path("custom_components/robovac/vacuum.py")
+REPORT_DIR = Path("mutation-reports")
+
+CRITICAL_COMMANDS = {"START_PAUSE", "RETURN_HOME", "MODE", "STATUS"}
+GENERIC_MAPPING_TESTS = (
+    "tests/test_vacuum/test_dps_command_mapping.py",
+    "tests/test_vacuum/test_get_robovac_command_value.py",
+    "tests/test_vacuum/test_get_robovac_human_readable_value.py",
+    "tests/test_vacuum/test_legacy_start_pause_mappings.py",
+)
+ROOM_COMMAND_TESTS = (
+    "tests/test_vacuum/test_vacuum_commands.py",
+    "tests/test_vacuum/test_vacuum_entity.py",
+)
+
+
+@dataclass(frozen=True)
+class Mutation:
+    """A single mapping mutation to apply to a temporary source copy."""
+
+    id: str
+    path: str
+    description: str
+    kind: str
+    model: str | None = None
+    command: str | None = None
+    detail: str | None = None
+    occurrence: int | None = None
+    target_lineno: int | None = None
+    target_col_offset: int | None = None
+    tests: tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass
+class MutationResult:
+    """Result for one mutation run."""
+
+    id: str
+    path: str
+    description: str
+    outcome: str
+    tests: tuple[str, ...]
+    duration_seconds: float
+    returncode: int | None = None
+    output_tail: str = ""
+
+
+def _command_name(node: ast.AST | None) -> str | None:
+    if (
+        isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "RobovacCommand"
+    ):
+        return node.attr
+    return None
+
+
+def _string_constant(node: ast.AST | None) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _find_dict_value(dictionary: ast.Dict, key: str) -> ast.AST | None:
+    for dict_key, value in zip(dictionary.keys, dictionary.values, strict=True):
+        if _string_constant(dict_key) == key:
+            return value
+    return None
+
+
+def _has_dict_key(dictionary: ast.Dict, key: str) -> bool:
+    return any(_string_constant(dict_key) == key for dict_key in dictionary.keys)
+
+
+def _model_test_paths(model: str) -> tuple[str, ...]:
+    model_test = f"tests/test_vacuum/test_{model.lower()}_command_mappings.py"
+    tests = [*GENERIC_MAPPING_TESTS]
+    if (ROOT / model_test).exists():
+        tests.insert(0, model_test)
+    return tuple(dict.fromkeys(tests))
+
+
+def _build_model_mutations(path: Path, tree: ast.Module) -> list[Mutation]:
+    mutations: list[Mutation] = []
+    relative = path.relative_to(ROOT).as_posix()
+    model = path.stem
+
+    for node in tree.body:
+        if not isinstance(node, ast.ClassDef) or node.name != model:
+            continue
+
+        for statement in node.body:
+            if not isinstance(statement, ast.Assign):
+                continue
+            if not any(isinstance(target, ast.Name) and target.id == "commands" for target in statement.targets):
+                continue
+            if not isinstance(statement.value, ast.Dict):
+                continue
+
+            for key_node, value_node in zip(statement.value.keys, statement.value.values, strict=True):
+                command = _command_name(key_node)
+                if command is None:
+                    continue
+
+                if command in CRITICAL_COMMANDS:
+                    mutations.append(
+                        Mutation(
+                            id=f"{model}:{command}:remove-command",
+                            path=relative,
+                            model=model,
+                            command=command,
+                            kind="remove_command",
+                            description=f"Remove {command} command from {model}",
+                            tests=_model_test_paths(model),
+                        )
+                    )
+
+                if isinstance(value_node, ast.Dict):
+                    code_value = _find_dict_value(value_node, "code")
+                    if _is_mutable_code(code_value):
+                        mutations.extend(
+                            _code_mutations(
+                                relative=relative,
+                                model=model,
+                                command=command,
+                                tests=_model_test_paths(model),
+                            )
+                        )
+
+                    if _has_dict_key(value_node, "values"):
+                        mutations.append(
+                            Mutation(
+                                id=f"{model}:{command}:remove-values",
+                                path=relative,
+                                model=model,
+                                command=command,
+                                kind="remove_values",
+                                description=f"Remove values mapping from {model} {command}",
+                                tests=_model_test_paths(model),
+                            )
+                        )
+
+                    if command == "START_PAUSE":
+                        values = _find_dict_value(value_node, "values")
+                        if isinstance(values, ast.Dict):
+                            for detail in ("start", "pause"):
+                                if _has_bool_value(values, detail):
+                                    mutations.append(
+                                        Mutation(
+                                            id=f"{model}:START_PAUSE:flip-{detail}",
+                                            path=relative,
+                                            model=model,
+                                            command=command,
+                                            detail=detail,
+                                            kind="flip_bool_value",
+                                            description=f"Flip {detail} boolean for {model} START_PAUSE",
+                                            tests=_model_test_paths(model),
+                                        )
+                                    )
+
+                    if command == "STATUS":
+                        values = _find_dict_value(value_node, "values")
+                        if isinstance(values, ast.Dict) and _has_dict_key(values, "Recharge"):
+                            mutations.append(
+                                Mutation(
+                                    id=f"{model}:STATUS:remove-Recharge",
+                                    path=relative,
+                                    model=model,
+                                    command=command,
+                                    detail="Recharge",
+                                    kind="remove_nested_value",
+                                    description=f"Remove Recharge status mapping from {model}",
+                                    tests=_model_test_paths(model),
+                                )
+                            )
+                elif _is_mutable_code(value_node):
+                    mutations.extend(
+                        _code_mutations(
+                            relative=relative,
+                            model=model,
+                            command=command,
+                            tests=_model_test_paths(model),
+                        )
+                    )
+
+    return mutations
+
+
+def _is_mutable_code(node: ast.AST | None) -> bool:
+    if isinstance(node, ast.Constant) and isinstance(node.value, int | str):
+        return isinstance(node.value, int) or node.value.isdigit()
+    return False
+
+
+def _code_mutations(
+    *, relative: str, model: str, command: str, tests: tuple[str, ...]
+) -> list[Mutation]:
+    return [
+        Mutation(
+            id=f"{model}:{command}:code-plus-one",
+            path=relative,
+            model=model,
+            command=command,
+            detail="plus_one",
+            kind="change_code",
+            description=f"Increment DPS code for {model} {command}",
+            tests=tests,
+        ),
+        Mutation(
+            id=f"{model}:{command}:code-minus-one",
+            path=relative,
+            model=model,
+            command=command,
+            detail="minus_one",
+            kind="change_code",
+            description=f"Decrement DPS code for {model} {command}",
+            tests=tests,
+        ),
+    ]
+
+
+def _has_bool_value(dictionary: ast.Dict, key: str) -> bool:
+    value = _find_dict_value(dictionary, key)
+    return isinstance(value, ast.Constant) and isinstance(value.value, bool)
+
+
+def _build_map_id_mutations(path: Path, tree: ast.Module) -> list[Mutation]:
+    mutations: list[Mutation] = []
+    relative = path.relative_to(ROOT).as_posix()
+
+    class Visitor(ast.NodeVisitor):
+        def __init__(self) -> None:
+            self.occurrence = 0
+
+        def visit_Constant(self, node: ast.Constant) -> None:
+            if node.value == "mapId":
+                mutations.append(
+                    Mutation(
+                        id=f"vacuum.py:mapId:{self.occurrence}",
+                        path=relative,
+                        occurrence=self.occurrence,
+                        target_lineno=node.lineno,
+                        target_col_offset=node.col_offset,
+                        kind="change_map_id_literal",
+                        description=(
+                            f"Change mapId literal occurrence {self.occurrence} "
+                            "in vacuum.py"
+                        ),
+                        tests=ROOM_COMMAND_TESTS,
+                    )
+                )
+                self.occurrence += 1
+
+    Visitor().visit(tree)
+    return mutations
+
+
+class MappingMutationTransformer(ast.NodeTransformer):
+    """Apply one requested mutation to a parsed source file."""
+
+    def __init__(self, mutation: Mutation) -> None:
+        self.mutation = mutation
+        self.applied = False
+
+    def visit_Constant(self, node: ast.Constant) -> ast.AST:
+        if (
+            self.mutation.kind == "change_map_id_literal"
+            and node.value == "mapId"
+            and node.lineno == self.mutation.target_lineno
+            and node.col_offset == self.mutation.target_col_offset
+        ):
+            self.applied = True
+            return ast.copy_location(ast.Constant("__mutated_mapId__"), node)
+        return node
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> ast.AST:
+        if self.mutation.kind == "change_map_id_literal":
+            return self.generic_visit(node)
+        if self.mutation.model is None or node.name != self.mutation.model:
+            return node
+        return self.generic_visit(node)
+
+    def visit_Assign(self, node: ast.Assign) -> ast.AST:
+        if self.mutation.kind == "change_map_id_literal":
+            return self.generic_visit(node)
+        if self.mutation.model is None:
+            return node
+        if not any(isinstance(target, ast.Name) and target.id == "commands" for target in node.targets):
+            return node
+        if isinstance(node.value, ast.Dict):
+            node.value = self._mutate_commands_dict(node.value)
+        return node
+
+    def _mutate_commands_dict(self, commands: ast.Dict) -> ast.Dict:
+        new_keys: list[ast.expr | None] = []
+        new_values: list[ast.expr] = []
+
+        for key_node, value_node in zip(commands.keys, commands.values, strict=True):
+            command = _command_name(key_node)
+            if command != self.mutation.command:
+                new_keys.append(key_node)
+                new_values.append(value_node)
+                continue
+
+            if self.mutation.kind == "remove_command":
+                self.applied = True
+                continue
+
+            new_keys.append(key_node)
+            new_values.append(self._mutate_command_value(value_node))
+
+        commands.keys = new_keys
+        commands.values = new_values
+        return commands
+
+    def _mutate_command_value(self, value_node: ast.expr) -> ast.expr:
+        if self.mutation.kind == "change_code" and _is_mutable_code(value_node):
+            self.applied = True
+            return self._change_code(value_node)
+
+        if not isinstance(value_node, ast.Dict):
+            return value_node
+
+        if self.mutation.kind == "remove_values":
+            return self._remove_top_level_key(value_node, "values")
+
+        if self.mutation.kind == "change_code":
+            return self._mutate_code_key(value_node)
+
+        if self.mutation.kind == "flip_bool_value":
+            return self._flip_bool_in_values(value_node)
+
+        if self.mutation.kind == "remove_nested_value":
+            return self._remove_nested_value(value_node)
+
+        return value_node
+
+    def _remove_top_level_key(self, dictionary: ast.Dict, key: str) -> ast.Dict:
+        new_keys: list[ast.expr | None] = []
+        new_values: list[ast.expr] = []
+        for dict_key, value in zip(dictionary.keys, dictionary.values, strict=True):
+            if _string_constant(dict_key) == key:
+                self.applied = True
+                continue
+            new_keys.append(dict_key)
+            new_values.append(value)
+        dictionary.keys = new_keys
+        dictionary.values = new_values
+        return dictionary
+
+    def _mutate_code_key(self, dictionary: ast.Dict) -> ast.Dict:
+        for index, dict_key in enumerate(dictionary.keys):
+            if _string_constant(dict_key) == "code":
+                dictionary.values[index] = self._change_code(dictionary.values[index])
+        return dictionary
+
+    def _change_code(self, node: ast.expr) -> ast.expr:
+        if not isinstance(node, ast.Constant):
+            return node
+        delta = 1 if self.mutation.detail == "plus_one" else -1
+        if isinstance(node.value, int):
+            self.applied = True
+            return ast.copy_location(ast.Constant(node.value + delta), node)
+        if isinstance(node.value, str) and node.value.isdigit():
+            self.applied = True
+            return ast.copy_location(ast.Constant(str(int(node.value) + delta)), node)
+        return node
+
+    def _flip_bool_in_values(self, dictionary: ast.Dict) -> ast.Dict:
+        values = _find_dict_value(dictionary, "values")
+        if not isinstance(values, ast.Dict):
+            return dictionary
+        for index, dict_key in enumerate(values.keys):
+            if _string_constant(dict_key) != self.mutation.detail:
+                continue
+            current = values.values[index]
+            if isinstance(current, ast.Constant) and isinstance(current.value, bool):
+                values.values[index] = ast.copy_location(ast.Constant(not current.value), current)
+                self.applied = True
+        return dictionary
+
+    def _remove_nested_value(self, dictionary: ast.Dict) -> ast.Dict:
+        values = _find_dict_value(dictionary, "values")
+        if not isinstance(values, ast.Dict) or self.mutation.detail is None:
+            return dictionary
+
+        new_keys: list[ast.expr | None] = []
+        new_values: list[ast.expr] = []
+        for dict_key, value in zip(values.keys, values.values, strict=True):
+            if _string_constant(dict_key) == self.mutation.detail:
+                self.applied = True
+                continue
+            new_keys.append(dict_key)
+            new_values.append(value)
+        values.keys = new_keys
+        values.values = new_values
+        return dictionary
+
+
+def build_mutations() -> list[Mutation]:
+    mutations: list[Mutation] = []
+    for path in sorted((ROOT / MODEL_DIR).glob("T*.py")):
+        tree = ast.parse(path.read_text(), filename=str(path))
+        mutations.extend(_build_model_mutations(path, tree))
+
+    vacuum_path = ROOT / VACUUM_ENTITY
+    mutations.extend(_build_map_id_mutations(vacuum_path, ast.parse(vacuum_path.read_text())))
+    return mutations
+
+
+def apply_mutation(temp_root: Path, mutation: Mutation) -> None:
+    path = temp_root / mutation.path
+    tree = ast.parse(path.read_text(), filename=str(path))
+    transformer = MappingMutationTransformer(mutation)
+    mutated = transformer.visit(tree)
+    ast.fix_missing_locations(mutated)
+    if not transformer.applied:
+        raise RuntimeError(f"Mutation was not applied: {mutation.id}")
+    path.write_text(ast.unparse(mutated) + "\n")
+
+
+def copy_project_subset(temp_root: Path) -> None:
+    shutil.copytree(ROOT / "custom_components", temp_root / "custom_components")
+    shutil.copytree(ROOT / "tests", temp_root / "tests")
+    for filename in ("pytest.ini", "pyproject.toml"):
+        shutil.copy2(ROOT / filename, temp_root / filename)
+
+
+def run_pytest(temp_root: Path, tests: tuple[str, ...], timeout: float) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONDONTWRITEBYTECODE"] = "1"
+    env["PYTHONPATH"] = f"{temp_root}{os.pathsep}{env.get('PYTHONPATH', '')}"
+    return subprocess.run(
+        [sys.executable, "-m", "pytest", "-q", *tests],
+        cwd=temp_root,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def output_tail(output: str, lines: int = 30) -> str:
+    return "\n".join(output.splitlines()[-lines:])
+
+
+def run_mutation(mutation: Mutation, timeout: float) -> MutationResult:
+    start = time.monotonic()
+    with tempfile.TemporaryDirectory(prefix="robovac-mapping-mutant-") as temp_dir:
+        temp_root = Path(temp_dir)
+        copy_project_subset(temp_root)
+        apply_mutation(temp_root, mutation)
+        try:
+            completed = run_pytest(temp_root, mutation.tests, timeout)
+        except subprocess.TimeoutExpired as exc:
+            return MutationResult(
+                id=mutation.id,
+                path=mutation.path,
+                description=mutation.description,
+                outcome="timeout",
+                tests=mutation.tests,
+                duration_seconds=round(time.monotonic() - start, 3),
+                output_tail=output_tail(exc.output or ""),
+            )
+
+    return MutationResult(
+        id=mutation.id,
+        path=mutation.path,
+        description=mutation.description,
+        outcome="survived" if completed.returncode == 0 else "killed",
+        tests=mutation.tests,
+        duration_seconds=round(time.monotonic() - start, 3),
+        returncode=completed.returncode,
+        output_tail=output_tail(completed.stdout),
+    )
+
+
+def verify_baseline(timeout: float) -> None:
+    tests = tuple(dict.fromkeys([*GENERIC_MAPPING_TESTS, *ROOM_COMMAND_TESTS]))
+    with tempfile.TemporaryDirectory(prefix="robovac-mapping-baseline-") as temp_dir:
+        temp_root = Path(temp_dir)
+        copy_project_subset(temp_root)
+        completed = run_pytest(temp_root, tests, timeout)
+    if completed.returncode != 0:
+        print("Baseline tests failed in temporary mutation workspace.", file=sys.stderr)
+        print(output_tail(completed.stdout), file=sys.stderr)
+        raise SystemExit(2)
+
+
+def write_reports(report_dir: Path, mutations: list[Mutation], results: list[MutationResult]) -> None:
+    report_dir.mkdir(parents=True, exist_ok=True)
+    payload: dict[str, Any] = {
+        "total_mutations": len(mutations),
+        "executed_mutations": len(results),
+        "killed": sum(result.outcome == "killed" for result in results),
+        "survived": sum(result.outcome == "survived" for result in results),
+        "timeout": sum(result.outcome == "timeout" for result in results),
+        "results": [asdict(result) for result in results],
+    }
+    (report_dir / "model-mapping-mutations.json").write_text(json.dumps(payload, indent=2) + "\n")
+
+    survivors = [result for result in results if result.outcome == "survived"]
+    lines = [
+        "# RoboVac Mapping Mutation Report",
+        "",
+        f"- Total discovered mutations: {len(mutations)}",
+        f"- Executed mutations: {len(results)}",
+        f"- Killed: {payload['killed']}",
+        f"- Survived: {payload['survived']}",
+        f"- Timed out: {payload['timeout']}",
+        "",
+    ]
+    if survivors:
+        lines.extend(
+            [
+                "## Survivors",
+                "",
+                "| ID | Path | Description | Tests |",
+                "| --- | --- | --- | --- |",
+            ]
+        )
+        for survivor in survivors:
+            tests = "<br>".join(survivor.tests)
+            lines.append(
+                f"| `{survivor.id}` | `{survivor.path}` | {survivor.description} | {tests} |"
+            )
+        lines.append("")
+    else:
+        lines.extend(["No surviving mapping mutants.", ""])
+
+    (report_dir / "model-mapping-mutations.md").write_text("\n".join(lines))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--max-mutants",
+        type=int,
+        default=None,
+        help="Limit execution to the first N discovered mutants for smoke testing.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=90.0,
+        help="Per-mutant pytest timeout in seconds.",
+    )
+    parser.add_argument(
+        "--report-dir",
+        type=Path,
+        default=REPORT_DIR,
+        help="Directory for JSON and Markdown reports.",
+    )
+    parser.add_argument(
+        "--fail-on-survivors",
+        action="store_true",
+        help="Exit non-zero when any executed mutation survives.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    mutations = build_mutations()
+    selected = mutations[: args.max_mutants] if args.max_mutants is not None else mutations
+
+    print(f"Discovered {len(mutations)} mapping mutations.")
+    if args.max_mutants is not None:
+        print(f"Executing first {len(selected)} mutations.")
+
+    verify_baseline(args.timeout)
+
+    results: list[MutationResult] = []
+    for index, mutation in enumerate(selected, start=1):
+        print(f"[{index}/{len(selected)}] {mutation.id}: {mutation.description}")
+        result = run_mutation(mutation, args.timeout)
+        print(f"  -> {result.outcome} in {result.duration_seconds:.3f}s")
+        results.append(result)
+
+    write_reports(args.report_dir, mutations, results)
+
+    survivors = [result for result in results if result.outcome == "survived"]
+    print(
+        "Mapping mutation report written to "
+        f"{args.report_dir / 'model-mapping-mutations.md'}"
+    )
+    print(f"Killed: {sum(result.outcome == 'killed' for result in results)}")
+    print(f"Survived: {len(survivors)}")
+    print(f"Timed out: {sum(result.outcome == 'timeout' for result in results)}")
+
+    if args.fail_on_survivors and survivors:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_mutate_model_mappings.py
+++ b/tests/test_mutate_model_mappings.py
@@ -1,0 +1,53 @@
+"""Tests for the RoboVac model mapping mutation audit script."""
+
+import ast
+import shutil
+from pathlib import Path
+
+from scripts import mutate_model_mappings
+
+
+def _map_id_locations(tree: ast.AST) -> list[tuple[int, int]]:
+    """Return mapId string literal locations in NodeVisitor traversal order."""
+    locations: list[tuple[int, int]] = []
+
+    class Visitor(ast.NodeVisitor):
+        def visit_Constant(self, node: ast.Constant) -> None:
+            if node.value == "mapId":
+                locations.append((node.lineno, node.col_offset))
+
+    Visitor().visit(tree)
+    return locations
+
+
+def test_map_id_mutations_apply_to_matching_literal_occurrences(tmp_path: Path) -> None:
+    """Map ID mutations should apply and target the same traversal order used to discover them."""
+    source_file = mutate_model_mappings.ROOT / mutate_model_mappings.VACUUM_ENTITY
+    expected_locations = _map_id_locations(ast.parse(source_file.read_text()))
+    mutations = [
+        mutation
+        for mutation in mutate_model_mappings.build_mutations()
+        if mutation.kind == "change_map_id_literal"
+    ]
+
+    assert len(mutations) == len(expected_locations)
+
+    for mutation, expected_location in zip(mutations, expected_locations, strict=True):
+        temp_root = tmp_path / mutation.id.replace(":", "-")
+        target_file = temp_root / mutation.path
+        target_file.parent.mkdir(parents=True)
+        shutil.copy2(source_file, target_file)
+
+        tree = ast.parse(target_file.read_text())
+        transformer = mutate_model_mappings.MappingMutationTransformer(mutation)
+        mutated_tree = transformer.visit(tree)
+        mutated_sentinel_locations = [
+            (node.lineno, node.col_offset)
+            for node in ast.walk(mutated_tree)
+            if isinstance(node, ast.Constant) and node.value == "__mutated_mapId__"
+        ]
+
+        assert mutated_sentinel_locations == [expected_location]
+        assert transformer.applied
+
+        mutate_model_mappings.apply_mutation(temp_root, mutation)

--- a/tests/test_vacuum/test_t1250_command_mappings.py
+++ b/tests/test_vacuum/test_t1250_command_mappings.py
@@ -1,0 +1,99 @@
+"""Tests for T1250 command mappings and DPS codes."""
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from custom_components.robovac.robovac import RoboVac
+from custom_components.robovac.vacuums.base import RobovacCommand
+
+
+@pytest.fixture
+def mock_t1250_robovac() -> RoboVac:
+    """Create a mock T1250 RoboVac instance for mapping tests."""
+    with patch("custom_components.robovac.robovac.TuyaDevice.__init__", return_value=None):
+        return RoboVac(
+            model_code="T1250",
+            device_id="test_id",
+            host="192.168.1.100",
+            local_key="test_key",
+        )
+
+
+def _command_code(command: Any) -> str | None:
+    """Return a command DPS code as a string."""
+    if isinstance(command, dict) and "code" in command:
+        return str(command["code"])
+    if not isinstance(command, dict):
+        return str(command)
+    return None
+
+
+def test_t1250_model_has_required_commands(mock_t1250_robovac: RoboVac) -> None:
+    """Test that T1250 exposes required command mappings."""
+    commands = mock_t1250_robovac.model_details.commands
+
+    assert RobovacCommand.START_PAUSE in commands
+    assert RobovacCommand.DIRECTION in commands
+    assert RobovacCommand.MODE in commands
+    assert RobovacCommand.STATUS in commands
+    assert RobovacCommand.RETURN_HOME in commands
+    assert RobovacCommand.FAN_SPEED in commands
+    assert RobovacCommand.LOCATE in commands
+    assert RobovacCommand.BATTERY in commands
+    assert RobovacCommand.ERROR in commands
+
+
+@pytest.mark.parametrize(
+    ("command", "expected_code"),
+    (
+        (RobovacCommand.START_PAUSE, "2"),
+        (RobovacCommand.DIRECTION, "3"),
+        (RobovacCommand.STATUS, "15"),
+        (RobovacCommand.RETURN_HOME, "101"),
+        (RobovacCommand.LOCATE, "103"),
+        (RobovacCommand.BATTERY, "104"),
+        (RobovacCommand.ERROR, "106"),
+    ),
+)
+def test_t1250_command_dps_codes(
+    mock_t1250_robovac: RoboVac,
+    command: RobovacCommand,
+    expected_code: str,
+) -> None:
+    """Test T1250 command DPS codes."""
+    commands = mock_t1250_robovac.model_details.commands
+
+    assert _command_code(commands[command]) == expected_code
+
+
+def test_t1250_start_pause_values(mock_t1250_robovac: RoboVac) -> None:
+    """Test T1250 START_PAUSE maps start/pause to booleans."""
+    assert mock_t1250_robovac.getRoboVacCommandValue(RobovacCommand.START_PAUSE, "start") is True
+    assert mock_t1250_robovac.getRoboVacCommandValue(RobovacCommand.START_PAUSE, "pause") is False
+
+
+def test_t1250_direction_command_values(mock_t1250_robovac: RoboVac) -> None:
+    """Test T1250 DIRECTION command value mappings."""
+    assert mock_t1250_robovac.getRoboVacCommandValue(RobovacCommand.DIRECTION, "forward") == "Forward"
+    assert mock_t1250_robovac.getRoboVacCommandValue(RobovacCommand.DIRECTION, "back") == "Back"
+    assert mock_t1250_robovac.getRoboVacCommandValue(RobovacCommand.DIRECTION, "left") == "Left"
+    assert mock_t1250_robovac.getRoboVacCommandValue(RobovacCommand.DIRECTION, "right") == "Right"
+
+
+def test_t1250_mode_command_values(mock_t1250_robovac: RoboVac) -> None:
+    """Test T1250 MODE command value mappings."""
+    assert mock_t1250_robovac.getRoboVacCommandValue(RobovacCommand.MODE, "auto") == "Auto"
+    assert mock_t1250_robovac.getRoboVacCommandValue(RobovacCommand.MODE, "small_room") == "SmallRoom"
+    assert mock_t1250_robovac.getRoboVacCommandValue(RobovacCommand.MODE, "spot") == "Spot"
+    assert mock_t1250_robovac.getRoboVacCommandValue(RobovacCommand.MODE, "edge") == "Edge"
+    assert mock_t1250_robovac.getRoboVacCommandValue(RobovacCommand.MODE, "nosweep") == "Nosweep"
+
+
+def test_t1250_fan_speed_command_values(mock_t1250_robovac: RoboVac) -> None:
+    """Test T1250 FAN_SPEED command value mappings."""
+    assert mock_t1250_robovac.getRoboVacCommandValue(RobovacCommand.FAN_SPEED, "standard") == "Standard"
+    assert mock_t1250_robovac.getRoboVacCommandValue(RobovacCommand.FAN_SPEED, "turbo") == "Turbo"
+    assert mock_t1250_robovac.getRoboVacCommandValue(RobovacCommand.FAN_SPEED, "max") == "Max"
+    assert mock_t1250_robovac.getRoboVacCommandValue(RobovacCommand.FAN_SPEED, "boost_iq") == "Boost_IQ"

--- a/uv.lock
+++ b/uv.lock
@@ -4,5 +4,5 @@ requires-python = ">=3.14.2"
 
 [[package]]
 name = "robovac"
-version = "2.4.1b1"
+version = "2.4.3"
 source = { editable = "." }


### PR DESCRIPTION
## Summary
- Add advisory mutmut configuration and Taskfile commands.
- Add a temp-copy RoboVac model mapping mutation audit.
- Add T1250 mapping contract tests that kill the initial survivors.

## Test Plan
- `task mutation:mappings -- --max-mutants 20`
- `task test`
- `task type-check`
- `task lint`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/robovac/pull/521" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->