### PR TITLE
feat(T2258): add documented T2258 support

### DIFF
--- a/custom_components/robovac/robovac.py
+++ b/custom_components/robovac/robovac.py
@@ -243,6 +243,29 @@ class RoboVac(TuyaDevice):
 
         return value
 
+    def supportsRoboVacCommandValue(
+        self, command_name: RobovacCommand, value: str
+    ) -> bool:
+        """Return whether a model explicitly supports a command value.
+
+        Commands without a model-specific values table keep their existing
+        passthrough behavior.
+        """
+        try:
+            cmd = (
+                command_name
+                if isinstance(command_name, RobovacCommand)
+                else RobovacCommand(command_name)
+            )
+            values = self._get_command_values(cmd)
+        except (ValueError, KeyError):
+            return True
+
+        if values is None:
+            return True
+
+        return value in values
+
     def getRoboVacHumanReadableValue(self, command_name: RobovacCommand, value: str) -> str:
         """Convert model-specific device value to human-readable command value.
 

--- a/custom_components/robovac/vacuum.py
+++ b/custom_components/robovac/vacuum.py
@@ -410,6 +410,18 @@ class RoboVacEntity(StateVacuumEntity):
             return value == "True" or value.lower() == "true"
         return False
 
+    def _supports_command_value(self, command: RobovacCommand, value: str) -> bool:
+        """Return whether the current model supports a command value."""
+        if self.vacuum is None:
+            return False
+
+        supports_value = getattr(self.vacuum, "supportsRoboVacCommandValue", None)
+        if not callable(supports_value):
+            return True
+
+        supported = supports_value(command, value)
+        return supported if isinstance(supported, bool) else True
+
     def _get_mode_command_data(self, mode: str) -> dict[str, str | bool] | None:
         """Helper method to get mode command data for the vacuum.
 
@@ -425,6 +437,9 @@ class RoboVacEntity(StateVacuumEntity):
         """
         if self.vacuum is None:
             return None
+
+        if not self._supports_command_value(RobovacCommand.MODE, mode):
+            raise HomeAssistantError(f"{self.model_code} does not support mode {mode}")
 
         return {
             self.get_dps_code("MODE"): self.vacuum.getRoboVacCommandValue(RobovacCommand.MODE, mode)
@@ -1682,6 +1697,12 @@ class RoboVacEntity(StateVacuumEntity):
                 self.get_dps_code("DO_NOT_DISTURB"): new_value
             })
         elif command == "boostIQ":
+            if not self.robovac_supported or not (
+                self.robovac_supported & RoboVacEntityFeature.BOOST_IQ
+            ):
+                raise HomeAssistantError(
+                    f"{self.model_code} does not support BoostIQ setting"
+                )
             # Toggle the boost IQ setting
             new_value = not self._is_value_true(self.boost_iq)
             await self.vacuum.async_set({

--- a/custom_components/robovac/vacuums/T2258.py
+++ b/custom_components/robovac/vacuums/T2258.py
@@ -1,0 +1,65 @@
+"""RoboVac G20 Hybrid (T2258)."""
+from homeassistant.components.vacuum import VacuumEntityFeature
+from .base import RoboVacEntityFeature, RobovacCommand, RobovacModelDetails
+
+
+class T2258(RobovacModelDetails):
+    homeassistant_features = (
+        VacuumEntityFeature.CLEAN_SPOT
+        | VacuumEntityFeature.FAN_SPEED
+        | VacuumEntityFeature.LOCATE
+        | VacuumEntityFeature.PAUSE
+        | VacuumEntityFeature.RETURN_HOME
+        | VacuumEntityFeature.SEND_COMMAND
+        | VacuumEntityFeature.START
+        | VacuumEntityFeature.STATE
+        | VacuumEntityFeature.STOP
+    )
+    robovac_features = (
+        RoboVacEntityFeature.CLEANING_TIME
+        | RoboVacEntityFeature.CLEANING_AREA
+        | RoboVacEntityFeature.DO_NOT_DISTURB
+        | RoboVacEntityFeature.AUTO_RETURN
+        | RoboVacEntityFeature.CONSUMABLES
+    )
+    commands = {
+        RobovacCommand.START_PAUSE: {
+            "code": 2,
+            "values": {"start": True, "pause": False},
+        },
+        RobovacCommand.MODE: {
+            "code": 5,
+            "values": {
+                "auto": "Auto",
+                "spot": "Spot",
+            },
+        },
+        RobovacCommand.STATUS: {
+            "code": 15,
+        },
+        RobovacCommand.RETURN_HOME: {
+            "code": 101,
+        },
+        RobovacCommand.FAN_SPEED: {
+            "code": 102,
+            "values": {
+                "quiet": "Quiet",
+                "standard": "Standard",
+                "turbo": "Turbo",
+                "max": "Max",
+                "boost_iq": "Boost_IQ",
+            },
+        },
+        RobovacCommand.LOCATE: {
+            "code": 103,
+        },
+        RobovacCommand.BATTERY: {
+            "code": 104,
+        },
+        RobovacCommand.ERROR: {
+            "code": 106,
+            "values": {
+                "0": "No error",
+            },
+        },
+    }

--- a/custom_components/robovac/vacuums/T2258.py
+++ b/custom_components/robovac/vacuums/T2258.py
@@ -21,6 +21,7 @@ class T2258(RobovacModelDetails):
         | RoboVacEntityFeature.DO_NOT_DISTURB
         | RoboVacEntityFeature.AUTO_RETURN
         | RoboVacEntityFeature.CONSUMABLES
+        | RoboVacEntityFeature.BOOST_IQ
     )
     commands = {
         RobovacCommand.START_PAUSE: {
@@ -47,7 +48,6 @@ class T2258(RobovacModelDetails):
                 "standard": "Standard",
                 "turbo": "Turbo",
                 "max": "Max",
-                "boost_iq": "Boost_IQ",
             },
         },
         RobovacCommand.LOCATE: {

--- a/custom_components/robovac/vacuums/__init__.py
+++ b/custom_components/robovac/vacuums/__init__.py
@@ -25,6 +25,7 @@ from .T2252 import T2252
 from .T2253 import T2253
 from .T2254 import T2254
 from .T2255 import T2255
+from .T2258 import T2258
 from .T2259 import T2259
 from .T2261 import T2261
 from .T2262 import T2262
@@ -63,6 +64,7 @@ ROBOVAC_MODELS: Dict[str, Type[RobovacModelDetails]] = {
     "T2210": T2210,
     "T2212": T2212,
     "T2255": T2255,
+    "T2258": T2258,
     "T2259": T2259,
     "T2270": T2270,
     "T2272": T2272,

--- a/site_docs/supported-models.md
+++ b/site_docs/supported-models.md
@@ -27,8 +27,9 @@ This page lists all currently supported Eufy RoboVac models.
 | T2251      | RoboVac G30 Edge     | 3.3      |
 | T2252      | RoboVac G30 Verge    | 3.3      |
 | T2253      | RoboVac G30 Hybrid   | 3.3      |
-| T2254      | RoboVac G20 Hybrid   | 3.3      |
-| T2255      | RoboVac G35+         | 3.3      |
+| T2254      | eufy Clean G35       | 3.3      |
+| T2255      | eufy Clean G40       | 3.3      |
+| T2258      | RoboVac G20 Hybrid   | 3.3      |
 | T2259      | RoboVac G40+         | 3.3      |
 | T2261      | RoboVac X8           | 3.3      |
 | T2262      | RoboVac X8 Hybrid    | 3.3      |
@@ -51,11 +52,11 @@ series, it may work with an existing configuration.
 
 ### G Series (Basic)
 
-- **G20**: T2181, T2254, T2272
+- **G20**: T2181, T2258, T2272
 - **G30**: T2190, T2250, T2251, T2252, T2253, T2273
 - **G32**: T2270
-- **G35**: T2255
-- **G40**: T1250, T2259, T2277, T2278, T2280
+- **G35**: T2254
+- **G40**: T1250, T2255, T2259, T2277, T2278, T2280
 
 ### X Series (Premium)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,7 +88,9 @@ def mock_robovac() -> MagicMock:
 
     mock.getRoboVacCommandValue.side_effect = command_value_side_effect
     mock.getRoboVacFeatures.return_value = (
-        RoboVacEntityFeature.EDGE | RoboVacEntityFeature.SMALL_ROOM
+        RoboVacEntityFeature.EDGE
+        | RoboVacEntityFeature.SMALL_ROOM
+        | RoboVacEntityFeature.BOOST_IQ
     )
     mock.getFanSpeeds.return_value = ["No Suction", "Standard", "Boost IQ", "Max"]
     mock._dps = {}

--- a/tests/test_vacuum/test_t2258_command_mappings.py
+++ b/tests/test_vacuum/test_t2258_command_mappings.py
@@ -1,0 +1,85 @@
+"""Tests for T2258 command mappings and DPS codes."""
+
+import pytest
+from unittest.mock import patch
+
+from custom_components.robovac.robovac import RoboVac
+from custom_components.robovac.vacuums.base import (
+    RoboVacEntityFeature,
+    RobovacCommand,
+)
+
+
+@pytest.fixture
+def mock_t2258_robovac() -> RoboVac:
+    """Create a mock T2258 RoboVac instance for testing."""
+    with patch("custom_components.robovac.robovac.TuyaDevice.__init__", return_value=None):
+        return RoboVac(
+            model_code="T2258",
+            device_id="test_id",
+            host="192.168.1.100",
+            local_key="test_key",
+        )
+
+
+def test_t2258_uses_documented_cleaning_modes(mock_t2258_robovac) -> None:
+    """Test T2258 only exposes documented Auto and Spot modes."""
+    values = mock_t2258_robovac.model_details.commands[RobovacCommand.MODE]["values"]
+
+    assert values == {
+        "auto": "Auto",
+        "spot": "Spot",
+    }
+    assert mock_t2258_robovac.getRoboVacCommandValue(RobovacCommand.MODE, "auto") == "Auto"
+    assert mock_t2258_robovac.getRoboVacCommandValue(RobovacCommand.MODE, "spot") == "Spot"
+
+
+def test_t2258_excludes_undocumented_mode_values(mock_t2258_robovac) -> None:
+    """Test T2258 does not expose undocumented G-series cleaning modes."""
+    values = mock_t2258_robovac.model_details.commands[RobovacCommand.MODE]["values"]
+
+    assert "small_room" not in values
+    assert "edge" not in values
+    assert "nosweep" not in values
+
+
+def test_t2258_uses_documented_suction_levels_and_boost_iq(mock_t2258_robovac) -> None:
+    """Test T2258 exposes documented suction levels and BoostIQ fan speed."""
+    values = mock_t2258_robovac.model_details.commands[RobovacCommand.FAN_SPEED]["values"]
+
+    assert values == {
+        "quiet": "Quiet",
+        "standard": "Standard",
+        "turbo": "Turbo",
+        "max": "Max",
+        "boost_iq": "Boost_IQ",
+    }
+    assert mock_t2258_robovac.getRoboVacCommandValue(RobovacCommand.FAN_SPEED, "quiet") == "Quiet"
+    assert mock_t2258_robovac.getRoboVacCommandValue(RobovacCommand.FAN_SPEED, "standard") == "Standard"
+    assert mock_t2258_robovac.getRoboVacCommandValue(RobovacCommand.FAN_SPEED, "turbo") == "Turbo"
+    assert mock_t2258_robovac.getRoboVacCommandValue(RobovacCommand.FAN_SPEED, "max") == "Max"
+    assert mock_t2258_robovac.getRoboVacCommandValue(RobovacCommand.FAN_SPEED, "boost_iq") == "Boost_IQ"
+
+
+def test_t2258_does_not_expose_boost_iq_as_separate_setting(mock_t2258_robovac) -> None:
+    """Test T2258 follows G-series BoostIQ fan speed behavior."""
+    assert not mock_t2258_robovac.model_details.robovac_features & RoboVacEntityFeature.BOOST_IQ
+
+
+def test_t2258_does_not_expose_direction_command(mock_t2258_robovac) -> None:
+    """Test T2258 does not expose undocumented manual direction controls."""
+    assert RobovacCommand.DIRECTION not in mock_t2258_robovac.model_details.commands
+
+
+def test_t2258_model_has_basic_commands(mock_t2258_robovac) -> None:
+    """Test that T2258 model has required basic commands defined."""
+    commands = mock_t2258_robovac.model_details.commands
+
+    assert RobovacCommand.START_PAUSE in commands
+    assert RobovacCommand.MODE in commands
+    assert RobovacCommand.STATUS in commands
+    assert RobovacCommand.RETURN_HOME in commands
+    assert RobovacCommand.FAN_SPEED in commands
+    assert RobovacCommand.LOCATE in commands
+    assert RobovacCommand.BATTERY in commands
+    assert RobovacCommand.ERROR in commands

--- a/tests/test_vacuum/test_t2258_command_mappings.py
+++ b/tests/test_vacuum/test_t2258_command_mappings.py
@@ -43,8 +43,8 @@ def test_t2258_excludes_undocumented_mode_values(mock_t2258_robovac) -> None:
     assert "nosweep" not in values
 
 
-def test_t2258_uses_documented_suction_levels_and_boost_iq(mock_t2258_robovac) -> None:
-    """Test T2258 exposes documented suction levels and BoostIQ fan speed."""
+def test_t2258_uses_documented_suction_levels(mock_t2258_robovac) -> None:
+    """Test T2258 exposes documented suction levels."""
     values = mock_t2258_robovac.model_details.commands[RobovacCommand.FAN_SPEED]["values"]
 
     assert values == {
@@ -52,18 +52,17 @@ def test_t2258_uses_documented_suction_levels_and_boost_iq(mock_t2258_robovac) -
         "standard": "Standard",
         "turbo": "Turbo",
         "max": "Max",
-        "boost_iq": "Boost_IQ",
     }
     assert mock_t2258_robovac.getRoboVacCommandValue(RobovacCommand.FAN_SPEED, "quiet") == "Quiet"
     assert mock_t2258_robovac.getRoboVacCommandValue(RobovacCommand.FAN_SPEED, "standard") == "Standard"
     assert mock_t2258_robovac.getRoboVacCommandValue(RobovacCommand.FAN_SPEED, "turbo") == "Turbo"
     assert mock_t2258_robovac.getRoboVacCommandValue(RobovacCommand.FAN_SPEED, "max") == "Max"
-    assert mock_t2258_robovac.getRoboVacCommandValue(RobovacCommand.FAN_SPEED, "boost_iq") == "Boost_IQ"
+    assert "boost_iq" not in values
 
 
-def test_t2258_does_not_expose_boost_iq_as_separate_setting(mock_t2258_robovac) -> None:
-    """Test T2258 follows G-series BoostIQ fan speed behavior."""
-    assert not mock_t2258_robovac.model_details.robovac_features & RoboVacEntityFeature.BOOST_IQ
+def test_t2258_exposes_boost_iq_as_separate_setting(mock_t2258_robovac) -> None:
+    """Test T2258 follows documented BoostIQ feature behavior."""
+    assert mock_t2258_robovac.model_details.robovac_features & RoboVacEntityFeature.BOOST_IQ
 
 
 def test_t2258_does_not_expose_direction_command(mock_t2258_robovac) -> None:
@@ -83,3 +82,8 @@ def test_t2258_model_has_basic_commands(mock_t2258_robovac) -> None:
     assert RobovacCommand.LOCATE in commands
     assert RobovacCommand.BATTERY in commands
     assert RobovacCommand.ERROR in commands
+
+
+def test_t2258_does_not_override_default_boost_iq_dps_code(mock_t2258_robovac) -> None:
+    """Test T2258 relies on the default BoostIQ DPS fallback."""
+    assert mock_t2258_robovac.getDpsCodes().get("BOOST_IQ") is None

--- a/tests/test_vacuum/test_vacuum_commands.py
+++ b/tests/test_vacuum/test_vacuum_commands.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     CONF_MODEL,
     CONF_NAME,
 )
+from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.robovac.proto_decode import decode_clean_param_response
 from custom_components.robovac.robovac import RoboVac
@@ -478,6 +479,65 @@ async def test_async_send_command(mock_robovac, mock_vacuum_data) -> None:
         entity._attr_boost_iq = True
         await entity.async_send_command("boostIQ")
         mock_robovac.async_set.assert_called_once_with({"118": False})
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("command", ["edgeClean", "smallRoomClean"])
+async def test_async_send_command_rejects_unsupported_t2258_modes(
+    mock_vacuum_data,
+    command,
+) -> None:
+    """Test T2258 does not send undocumented cleaning modes."""
+    with patch("custom_components.robovac.robovac.TuyaDevice.__init__", return_value=None):
+        robovac = RoboVac(
+            model_code="T2258",
+            device_id="test_id",
+            host="192.168.1.100",
+            local_key="test_key",
+        )
+    robovac.async_set = AsyncMock(return_value=True)
+    t2258_data = {
+        **mock_vacuum_data,
+        CONF_MODEL: "T2258",
+        CONF_DESCRIPTION: "RoboVac G20 Hybrid",
+    }
+
+    with patch("custom_components.robovac.vacuum.RoboVac", return_value=robovac):
+        entity = RoboVacEntity(t2258_data)
+
+    with pytest.raises(HomeAssistantError, match="does not support mode"):
+        await entity.async_send_command(command)
+
+    robovac.async_set.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_send_command_rejects_t2258_boost_iq_setting(
+    mock_vacuum_data,
+) -> None:
+    """Test T2258 does not send BoostIQ as a separate setting command."""
+    with patch("custom_components.robovac.robovac.TuyaDevice.__init__", return_value=None):
+        robovac = RoboVac(
+            model_code="T2258",
+            device_id="test_id",
+            host="192.168.1.100",
+            local_key="test_key",
+        )
+    robovac.async_set = AsyncMock(return_value=True)
+    t2258_data = {
+        **mock_vacuum_data,
+        CONF_MODEL: "T2258",
+        CONF_DESCRIPTION: "RoboVac G20 Hybrid",
+    }
+
+    with patch("custom_components.robovac.vacuum.RoboVac", return_value=robovac):
+        entity = RoboVacEntity(t2258_data)
+
+    entity._attr_boost_iq = False
+    with pytest.raises(HomeAssistantError, match="does not support BoostIQ setting"):
+        await entity.async_send_command("boostIQ")
+
+    robovac.async_set.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_vacuum/test_vacuum_commands.py
+++ b/tests/test_vacuum/test_vacuum_commands.py
@@ -512,10 +512,10 @@ async def test_async_send_command_rejects_unsupported_t2258_modes(
 
 
 @pytest.mark.asyncio
-async def test_async_send_command_rejects_t2258_boost_iq_setting(
+async def test_async_send_command_sends_t2258_boost_iq_setting(
     mock_vacuum_data,
 ) -> None:
-    """Test T2258 does not send BoostIQ as a separate setting command."""
+    """Test T2258 sends documented BoostIQ as a separate setting command."""
     with patch("custom_components.robovac.robovac.TuyaDevice.__init__", return_value=None):
         robovac = RoboVac(
             model_code="T2258",
@@ -533,11 +533,17 @@ async def test_async_send_command_rejects_t2258_boost_iq_setting(
     with patch("custom_components.robovac.vacuum.RoboVac", return_value=robovac):
         entity = RoboVacEntity(t2258_data)
 
-    entity._attr_boost_iq = False
-    with pytest.raises(HomeAssistantError, match="does not support BoostIQ setting"):
-        await entity.async_send_command("boostIQ")
+    assert entity.get_dps_code("BOOST_IQ") == "118"
 
-    robovac.async_set.assert_not_called()
+    entity._attr_boost_iq = False
+    await entity.async_send_command("boostIQ")
+    robovac.async_set.assert_called_once_with({"118": True})
+
+    robovac.async_set.reset_mock()
+
+    entity._attr_boost_iq = True
+    await entity.async_send_command("boostIQ")
+    robovac.async_set.assert_called_once_with({"118": False})
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Redoes #424 with T2258 support aligned to eufy's published RoboVac G20 Hybrid manual behavior. The follow-up check against eufy's G30 Edge manual shows BoostIQ is a fan-speed option there, but the T2258/G20 Hybrid manual documents BoostIQ as a separate selectable feature after the four suction levels.

- add and register `T2258` as `RoboVac G20 Hybrid`
- expose documented cleaning modes: `auto` and `spot`
- expose documented fan-speed values: `quiet`, `standard`, `turbo`, and `max`
- expose BoostIQ for T2258 as a separate `boostIQ` setting using the default DPS `118` fallback
- avoid undocumented `small_room`, `edge`, `nosweep`, and direction mappings for T2258
- fix supported-model docs for `T2254` as `eufy Clean G35` and `T2255` as `eufy Clean G40`

Credit to Phan Khánh for the original implementation in #424.

## Verification

- `uv run pytest tests/test_vacuum/test_t2258_command_mappings.py tests/test_vacuum/test_vacuum_commands.py`
- `uv run pytest tests/test_vacuum/test_t2254_command_mappings.py tests/test_vacuum/test_t2255_command_mappings.py tests/test_vacuum/test_t2259_command_mappings.py tests/test_vacuum/test_dps_command_mapping.py tests/test_vacuum/test_t2258_command_mappings.py tests/test_vacuum/test_vacuum_commands.py`
- `uv run flake8 custom_components/robovac/vacuums/T2258.py tests/test_vacuum/test_t2258_command_mappings.py tests/test_vacuum/test_vacuum_commands.py`
- `git diff --check`
