### PR TITLE
fix: record connection failures by DPS

### DIFF
--- a/custom_components/robovac/tuyalocalapi.py
+++ b/custom_components/robovac/tuyalocalapi.py
@@ -995,9 +995,13 @@ class TuyaDevice:
                 timeout=self.timeout,
             )
         except (asyncio.TimeoutError, OSError) as e:
-            self._dps[self.model_details.commands[RobovacCommand.ERROR]] = (
-                "CONNECTION_FAILED"
+            error_command = self.model_details.commands.get(RobovacCommand.ERROR, {})
+            error_dps = (
+                error_command.get("code")
+                if isinstance(error_command, dict)
+                else error_command
             )
+            self._dps[str(error_dps)] = "CONNECTION_FAILED"
             raise ConnectionTimeoutException("Connection timed out: {}".format(e))
         self._connected = True
 

--- a/tests/test_vacuum/test_tuyalocalapi_async_get.py
+++ b/tests/test_vacuum/test_tuyalocalapi_async_get.py
@@ -1,10 +1,19 @@
 """Tests for local Tuya status refresh behavior."""
 
+import asyncio
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
 
 import pytest
 
-from custom_components.robovac.tuyalocalapi import Message, TuyaDevice
+from custom_components.robovac.tuyalocalapi import (
+    ConnectionTimeoutException,
+    Message,
+    TuyaDevice,
+)
+from custom_components.robovac.vacuums.base import RobovacCommand
 
 
 @pytest.mark.asyncio
@@ -54,3 +63,31 @@ async def test_legacy_async_get_skips_status_request_during_backoff() -> None:
     device.async_receive.assert_not_awaited()
     assert device._queue == []
     assert device._listeners == {}
+
+
+@pytest.mark.asyncio
+async def test_async_connect_records_connection_failure_on_error_dps_code() -> None:
+    """Test connection timeouts update the error DPS without using dict keys."""
+    device = TuyaDevice.__new__(TuyaDevice)
+    device.model_details = SimpleNamespace(
+        commands={RobovacCommand.ERROR: {"code": 177}}
+    )
+    device.device_id = "test-device"
+    device.host = "192.0.2.10"
+    device.port = 6668
+    device.timeout = 0.1
+    device.version = (3, 5)
+    device._connected = False
+    device._enabled = True
+    device._last_connect_attempt = 0.0
+    device._dps = {}
+    device._LOGGER = MagicMock()
+
+    with patch(
+        "custom_components.robovac.tuyalocalapi.asyncio.open_connection",
+        new=AsyncMock(side_effect=asyncio.TimeoutError),
+    ):
+        with pytest.raises(ConnectionTimeoutException):
+            await device.async_connect()
+
+    assert device._dps["177"] == "CONNECTION_FAILED"


### PR DESCRIPTION
## Summary
- store connection timeout failures under the configured error DPS code instead of the command metadata dict
- add regression coverage for L60-style error DPS mappings

## Verification
- uv run pytest tests/test_vacuum/test_tuyalocalapi_async_get.py

Fixes #525