### PR TITLE
fix(T2275): correct L35 fan speeds

### DIFF
--- a/custom_components/robovac/vacuum.py
+++ b/custom_components/robovac/vacuum.py
@@ -707,6 +707,7 @@ class RoboVacEntity(StateVacuumEntity):
         self.tuyastatus: dict[str, Any] | None = None
         self._last_no_data_warning_time: float = 0
         self._no_data_warning_logged: bool = False
+        self._has_seen_data_points: bool = False
         self._consumables_codes_cache: list[str] | None = None
         self._dps_codes_memo: dict[str, str] = {}
         self._last_consumable_data: str | None = None
@@ -879,6 +880,9 @@ class RoboVacEntity(StateVacuumEntity):
         self.tuyastatus = self.vacuum._dps
 
         if self.tuyastatus is None or not self.tuyastatus:
+            if not self._has_seen_data_points:
+                _LOGGER.debug("Vacuum %s has no data points available yet", self.name)
+                return
             current_time = time.time()
             # Only log warning when state changes or after 5 minutes
             if not self._no_data_warning_logged or (current_time - self._last_no_data_warning_time) >= 300:
@@ -886,6 +890,8 @@ class RoboVacEntity(StateVacuumEntity):
                 self._last_no_data_warning_time = current_time
                 self._no_data_warning_logged = True
             return
+
+        self._has_seen_data_points = True
 
         # Reset warning state when data is available
         if self._no_data_warning_logged:

--- a/custom_components/robovac/vacuums/T2275.py
+++ b/custom_components/robovac/vacuums/T2275.py
@@ -37,10 +37,16 @@ class T2275(RobovacModelDetails):
                 "return_home": "AggB",
             },
         },
-        RobovacCommand.FAN_SPEED: {
+        RobovacCommand.CLEAN_PARAM: {
             "code": 154,
+        },
+        RobovacCommand.FAN_SPEED: {
+            "code": 158,
             "values": {
-                "fan_speed": "AgkBCgIKAQoDCgEKBAoB",
+                "quiet": "Quiet",
+                "standard": "Standard",
+                "turbo": "Turbo",
+                "max": "Max",
             },
         },
         RobovacCommand.LOCATE: {

--- a/tests/test_vacuum/test_logging_rate_limit.py
+++ b/tests/test_vacuum/test_logging_rate_limit.py
@@ -11,12 +11,14 @@ from custom_components.robovac.vacuum import RoboVacEntity
 
 @pytest.mark.asyncio
 async def test_no_data_warning_logged_once(mock_robovac, mock_vacuum_data: Any, caplog) -> None:
-    """Test that no data warning is logged only once initially."""
+    """Test that no data warning is logged only once after data was seen."""
     # Arrange
-    mock_robovac._dps = None
+    mock_robovac._dps = {"103": 100, "15": "Charging", "106": 0}
 
     with patch("custom_components.robovac.vacuum.RoboVac", return_value=mock_robovac):
         entity = RoboVacEntity(mock_vacuum_data)
+        entity.update_entity_values()
+        mock_robovac._dps = None
 
         # Act - call update_entity_values multiple times
         entity.update_entity_values()
@@ -36,10 +38,12 @@ async def test_no_data_warning_logged_once(mock_robovac, mock_vacuum_data: Any, 
 async def test_no_data_warning_logged_after_threshold(mock_robovac, mock_vacuum_data: Any, caplog) -> None:
     """Test that no data warning is logged again after 5 minute threshold."""
     # Arrange
-    mock_robovac._dps = None
+    mock_robovac._dps = {"103": 100, "15": "Charging", "106": 0}
 
     with patch("custom_components.robovac.vacuum.RoboVac", return_value=mock_robovac):
         entity = RoboVacEntity(mock_vacuum_data)
+        entity.update_entity_values()
+        mock_robovac._dps = None
 
         # Act - first call logs warning
         entity.update_entity_values()
@@ -69,10 +73,12 @@ async def test_no_data_warning_logged_after_threshold(mock_robovac, mock_vacuum_
 async def test_no_data_warning_not_logged_before_threshold(mock_robovac, mock_vacuum_data: Any, caplog) -> None:
     """Test that no data warning is not logged again before 5 minute threshold."""
     # Arrange
-    mock_robovac._dps = None
+    mock_robovac._dps = {"103": 100, "15": "Charging", "106": 0}
 
     with patch("custom_components.robovac.vacuum.RoboVac", return_value=mock_robovac):
         entity = RoboVacEntity(mock_vacuum_data)
+        entity.update_entity_values()
+        mock_robovac._dps = None
 
         # Act - first call logs warning
         entity.update_entity_values()
@@ -102,15 +108,17 @@ async def test_no_data_warning_not_logged_before_threshold(mock_robovac, mock_va
 async def test_data_recovery_info_logged(mock_robovac, mock_vacuum_data: Any, caplog) -> None:
     """Test that info message is logged when data becomes available after warning."""
     # Arrange
-    mock_robovac._dps = None
+    mock_robovac._dps = {"103": 100, "15": "Charging", "106": 0}
 
     with patch("custom_components.robovac.vacuum.RoboVac", return_value=mock_robovac):
         entity = RoboVacEntity(mock_vacuum_data)
-
-        # Act - first call with no data logs warning
         entity.update_entity_values()
 
-        # Now provide data
+        # Act - data disappears after it was previously available
+        mock_robovac._dps = None
+        entity.update_entity_values()
+
+        # Now provide data again
         mock_robovac._dps = {"103": 100, "15": "Charging", "106": 0}
         entity.update_entity_values()
 
@@ -150,12 +158,14 @@ async def test_no_info_logged_when_data_always_available(mock_robovac, mock_vacu
 async def test_warning_state_resets_after_data_recovery(mock_robovac, mock_vacuum_data: Any, caplog) -> None:
     """Test that warning state resets after data recovery and can be logged again."""
     # Arrange
-    mock_robovac._dps = None
+    mock_robovac._dps = {"103": 100, "15": "Charging", "106": 0}
 
     with patch("custom_components.robovac.vacuum.RoboVac", return_value=mock_robovac):
         entity = RoboVacEntity(mock_vacuum_data)
+        entity.update_entity_values()
 
         # Act - first no data period
+        mock_robovac._dps = None
         entity.update_entity_values()
         first_warning_count = sum(
             1 for record in caplog.records
@@ -171,7 +181,7 @@ async def test_warning_state_resets_after_data_recovery(mock_robovac, mock_vacuu
         mock_robovac._dps = None
         entity.update_entity_values()
 
-        # Assert - warning should be logged twice (once for each no-data period)
+        # Assert - warning should be logged twice after each post-data no-data period
         final_warning_count = sum(
             1 for record in caplog.records
             if record.levelname == "WARNING"

--- a/tests/test_vacuum/test_no_data_points_warning.py
+++ b/tests/test_vacuum/test_no_data_points_warning.py
@@ -69,6 +69,23 @@ def test_update_entity_values_with_valid_data(vacuum_entity):
     assert vacuum_entity.tuyastatus is not None
 
 
+def test_initial_empty_data_points_do_not_warn(mock_robovac, mock_vacuum_data, caplog):
+    """Initial empty DPS is not actionable and should not warn."""
+    mock_robovac._dps = {}
+
+    with patch("custom_components.robovac.vacuum.RoboVac", return_value=mock_robovac):
+        entity = RoboVacEntity(mock_vacuum_data)
+
+    entity.update_entity_values()
+
+    assert not [
+        record
+        for record in caplog.records
+        if record.levelname == "WARNING"
+        and "has no data points available" in record.message
+    ]
+
+
 def test_battery_sensor_exists_separately(vacuum_entity):
     """Test that battery level is handled by separate sensor, not vacuum entity."""
     # Battery level attribute should not exist on vacuum entity

--- a/tests/test_vacuum/test_t2275_command_mappings.py
+++ b/tests/test_vacuum/test_t2275_command_mappings.py
@@ -28,7 +28,8 @@ def test_t2275_dps_codes(mock_t2275_robovac) -> None:
     assert dps_codes["MODE"] == "152"
     assert dps_codes["STATUS"] == "173"
     assert dps_codes["RETURN_HOME"] == "153"
-    assert dps_codes["FAN_SPEED"] == "154"
+    assert dps_codes["CLEAN_PARAM"] == "154"
+    assert dps_codes["FAN_SPEED"] == "158"
     assert dps_codes["LOCATE"] == "153"
     assert dps_codes["BATTERY_LEVEL"] == "172"
     assert dps_codes["ERROR_CODE"] == "169"
@@ -59,15 +60,20 @@ def test_t2275_return_home_command_values(mock_t2275_robovac) -> None:
 
 
 def test_t2275_fan_speed_command_values(mock_t2275_robovac) -> None:
-    """Test T2275 FAN_SPEED value mapping."""
-    assert (
-        mock_t2275_robovac.getRoboVacCommandValue(RobovacCommand.FAN_SPEED, "fan_speed")
-        == "AgkBCgIKAQoDCgEKBAoB"
-    )
+    """Test T2275 FAN_SPEED maps HA selections to direct fan speed values."""
+    assert mock_t2275_robovac.getRoboVacCommandValue(RobovacCommand.FAN_SPEED, "quiet") == "Quiet"
+    assert mock_t2275_robovac.getRoboVacCommandValue(RobovacCommand.FAN_SPEED, "standard") == "Standard"
+    assert mock_t2275_robovac.getRoboVacCommandValue(RobovacCommand.FAN_SPEED, "turbo") == "Turbo"
+    assert mock_t2275_robovac.getRoboVacCommandValue(RobovacCommand.FAN_SPEED, "max") == "Max"
     assert (
         mock_t2275_robovac.getRoboVacCommandValue(RobovacCommand.FAN_SPEED, "unknown")
         == "unknown"
     )
+
+
+def test_t2275_fan_speed_list_exposes_real_speeds(mock_t2275_robovac) -> None:
+    """Test T2275 fan speed list does not expose the clean-param placeholder."""
+    assert mock_t2275_robovac.getFanSpeeds() == ["Quiet", "Standard", "Turbo", "Max"]
 
 
 def test_t2275_locate_command_values(mock_t2275_robovac) -> None:
@@ -83,7 +89,8 @@ def test_t2275_command_codes(mock_t2275_robovac) -> None:
     assert commands[RobovacCommand.MODE]["code"] == 152
     assert commands[RobovacCommand.STATUS]["code"] == 173
     assert commands[RobovacCommand.RETURN_HOME]["code"] == 153
-    assert commands[RobovacCommand.FAN_SPEED]["code"] == 154
+    assert commands[RobovacCommand.CLEAN_PARAM]["code"] == 154
+    assert commands[RobovacCommand.FAN_SPEED]["code"] == 158
     assert commands[RobovacCommand.LOCATE]["code"] == 153
     assert commands[RobovacCommand.BATTERY]["code"] == 172
     assert commands[RobovacCommand.ERROR]["code"] == 169


### PR DESCRIPTION
## Summary
- map L35 Hybrid clean params and direct fan speed DPS separately
- expose real L35 fan speed options instead of the clean-param placeholder
- suppress initial empty-DPS warnings until a vacuum has previously reported data, while preserving warning behavior after later data loss

## Verification
- ./.venv/bin/pytest tests/test_vacuum/test_t2275_command_mappings.py tests/test_vacuum/test_no_data_points_warning.py tests/test_vacuum/test_logging_rate_limit.py tests/test_vacuum/test_async_update_errors.py tests/test_vacuum/test_vacuum_entity.py
- uv run flake8 custom_components/robovac/vacuum.py custom_components/robovac/vacuums/T2275.py tests/test_vacuum/test_no_data_points_warning.py tests/test_vacuum/test_logging_rate_limit.py tests/test_vacuum/test_t2275_command_mappings.py

Fixes #333
Fixes #461
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/robovac/pull/528" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->