### PR TITLE
fix: preserve L60 SES custom starts

### DIFF
--- a/custom_components/robovac/config_flow.py
+++ b/custom_components/robovac/config_flow.py
@@ -191,6 +191,8 @@ def get_eufy_vacuums(self: dict[str, Any]) -> requests.Response:
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
     """Validate the user input allows us to connect."""
     await hass.async_add_executor_job(get_eufy_vacuums, data)
+    if not data.get(CONF_VACS):
+        raise NoVacuumsFound
     return data
 
 
@@ -216,6 +218,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore[call
             errors["base"] = "cannot_connect"
         except InvalidAuth:
             errors["base"] = "invalid_auth"
+        except NoVacuumsFound:
+            errors["base"] = "no_vacuums_found"
         except Exception as e:  # pylint: disable=broad-except
             _LOGGER.exception("Unexpected exception: {}".format(e))
             errors["base"] = "unknown"
@@ -244,6 +248,10 @@ class CannotConnect(HomeAssistantError):
 
 class InvalidAuth(HomeAssistantError):
     """Error to indicate there is invalid auth."""
+
+
+class NoVacuumsFound(HomeAssistantError):
+    """Error to indicate no compatible vacuums were discovered."""
 
 
 class OptionsFlowHandler(config_entries.OptionsFlow):

--- a/custom_components/robovac/strings.json
+++ b/custom_components/robovac/strings.json
@@ -6,6 +6,7 @@
         "error": {
             "cannot_connect": "Failed to connect",
             "invalid_auth": "Invalid authentication",
+            "no_vacuums_found": "No compatible RoboVac devices were found in your Eufy account",
             "unknown": "Unexpected error"
         },
         "step": {

--- a/custom_components/robovac/translations/cy.json
+++ b/custom_components/robovac/translations/cy.json
@@ -6,6 +6,7 @@
         "error": {
             "cannot_connect": "Wedi methu cysylltu",
             "invalid_auth": "Dilysiad annilys",
+            "no_vacuums_found": "Ni chanfuwyd unrhyw ddyfeisiau RoboVac cydnaws yn eich cyfrif Eufy",
             "unknown": "Gwall annisgwyl"
         },
         "step": {

--- a/custom_components/robovac/translations/de.json
+++ b/custom_components/robovac/translations/de.json
@@ -6,6 +6,7 @@
         "error": {
             "cannot_connect": "Verbindung fehlgeschlagen",
             "invalid_auth": "Ungültige Authentifizierung",
+            "no_vacuums_found": "In Ihrem Eufy-Konto wurden keine kompatiblen RoboVac-Geräte gefunden",
             "unknown": "Unerwarteter Fehler"
         },
         "step": {

--- a/custom_components/robovac/translations/en.json
+++ b/custom_components/robovac/translations/en.json
@@ -6,6 +6,7 @@
         "error": {
             "cannot_connect": "Failed to connect",
             "invalid_auth": "Invalid authentication",
+            "no_vacuums_found": "No compatible RoboVac devices were found in your Eufy account",
             "unknown": "Unexpected error"
         },
         "step": {

--- a/custom_components/robovac/translations/es.json
+++ b/custom_components/robovac/translations/es.json
@@ -6,6 +6,7 @@
         "error": {
             "cannot_connect": "Error al conectar",
             "invalid_auth": "Autenticación inválida",
+            "no_vacuums_found": "No se encontraron dispositivos RoboVac compatibles en tu cuenta de Eufy",
             "unknown": "Error inesperado"
         },
         "step": {

--- a/custom_components/robovac/translations/fr.json
+++ b/custom_components/robovac/translations/fr.json
@@ -6,6 +6,7 @@
         "error": {
             "cannot_connect": "Échec de la connexion",
             "invalid_auth": "Authentification invalide",
+            "no_vacuums_found": "Aucun appareil RoboVac compatible n'a été trouvé dans votre compte Eufy",
             "unknown": "Erreur inattendue"
         },
         "step": {

--- a/custom_components/robovac/translations/it.json
+++ b/custom_components/robovac/translations/it.json
@@ -6,6 +6,7 @@
         "error": {
             "cannot_connect": "Connessione non riuscita",
             "invalid_auth": "Autenticazione non valida",
+            "no_vacuums_found": "Nessun dispositivo RoboVac compatibile trovato nel tuo account Eufy",
             "unknown": "Errore imprevisto"
         },
         "step": {

--- a/custom_components/robovac/translations/nl.json
+++ b/custom_components/robovac/translations/nl.json
@@ -6,6 +6,7 @@
         "error": {
             "cannot_connect": "Verbinding mislukt",
             "invalid_auth": "Ongeldige authenticatie",
+            "no_vacuums_found": "Er zijn geen compatibele RoboVac-apparaten gevonden in je Eufy-account",
             "unknown": "Onverwachte fout"
         },
         "step": {

--- a/custom_components/robovac/translations/pt.json
+++ b/custom_components/robovac/translations/pt.json
@@ -6,6 +6,7 @@
         "error": {
             "cannot_connect": "Falha ao conectar",
             "invalid_auth": "Autenticação inválida",
+            "no_vacuums_found": "Nenhum dispositivo RoboVac compatível foi encontrado na sua conta Eufy",
             "unknown": "Erro inesperado"
         },
         "step": {

--- a/custom_components/robovac/vacuums/T2277.py
+++ b/custom_components/robovac/vacuums/T2277.py
@@ -43,7 +43,6 @@ class T2277(RobovacModelDetails):
         RobovacCommand.START_PAUSE: {
             "code": 152,
             "values": {
-                "start": "AggO",         # method=RESUME_TASK (14)
                 "pause": "AggN",         # method=PAUSE_TASK (13)
             },
         },

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -233,6 +233,43 @@ async def test_user_form_success(
 
 
 @pytest.mark.asyncio
+async def test_user_form_no_vacuums_found(
+    hass: HomeAssistant, mock_eufy_response
+) -> None:
+    """Test setup fails when no discovered vacuum has Tuya credentials."""
+    with (
+        patch(
+            "custom_components.robovac.config_flow.EufyLogon",
+            return_value=MagicMock(
+                get_user_info=MagicMock(return_value=mock_eufy_response["user_info"]),
+                get_device_info=MagicMock(
+                    return_value=mock_eufy_response["device_info"]
+                ),
+                get_user_settings=MagicMock(
+                    return_value=mock_eufy_response["settings"]
+                ),
+            ),
+        ),
+        patch(
+            "custom_components.robovac.config_flow.TuyaAPISession",
+            return_value=MagicMock(get_device=MagicMock(side_effect=Exception)),
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data={
+                CONF_USERNAME: "test-username",
+                CONF_PASSWORD: "test-password",
+            },
+        )
+
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "no_vacuums_found"}
+
+
+@pytest.mark.asyncio
 async def test_options_flow_init(hass: HomeAssistant) -> None:
     """Test options flow init step."""
     # Create a mock config entry using MagicMock instead of actual ConfigEntry

--- a/tests/test_vacuum/test_t2277_command_mappings.py
+++ b/tests/test_vacuum/test_t2277_command_mappings.py
@@ -60,6 +60,14 @@ def test_t2277_return_home_command_values(mock_t2277_robovac: RoboVac) -> None:
     )
 
 
+def test_t2277_start_pause_does_not_define_start_value(mock_t2277_robovac: RoboVac) -> None:
+    """GH-498: L60 SES HA Start must preserve app custom-clean settings."""
+    assert (
+        mock_t2277_robovac.getRoboVacCommandValue(RobovacCommand.START_PAUSE, "start")
+        == "start"
+    )
+
+
 def test_t2277_fan_speed_command_values(mock_t2277_robovac: RoboVac) -> None:
     """Test T2277 FAN_SPEED value mapping."""
     assert mock_t2277_robovac.getRoboVacCommandValue(RobovacCommand.FAN_SPEED, "quiet") == "Quiet"


### PR DESCRIPTION
## Summary
- remove the standalone T2277 START_PAUSE start payload so HA Start keeps using MODE auto
- add a GH-498 regression test for L60 SES custom-clean starts

Fixes #498

## Tests
- ./.venv/bin/pytest tests/test_vacuum/test_t2277_command_mappings.py tests/test_vacuum/test_l60_dps_codes.py tests/test_vacuum/test_vacuum_commands.py::test_async_start_does_not_overwrite_shared_dps_code
- ./.venv/bin/flake8 custom_components/robovac/vacuums/T2277.py tests/test_vacuum/test_t2277_command_mappings.py