### PR TITLE
Fix T2258 BoostIQ and add eufy PDF analysis

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -72,6 +72,11 @@ tasks:
     cmds:
       - uv run python scripts/cache_eufy_support_pdfs.py
 
+  analyze-eufy-pdfs:
+    desc: Analyze ignored eufy support PDF cache for names, modes, and features
+    cmds:
+      - uv run --with pypdf python scripts/analyze_eufy_support_pdfs.py --output .cache/eufy-support-pdfs/analysis.json
+
   markdownlint:
     desc: Lint with markdownlint
     cmds:

--- a/custom_components/robovac/robovac.py
+++ b/custom_components/robovac/robovac.py
@@ -152,7 +152,10 @@ class RoboVac(TuyaDevice):
         # Return the keys title-cased as display names for the UI
         # This ensures user-friendly names like "Pure" are shown even when
         # the device uses different internal values like "Quiet"
-        return [key.replace("_", " ").title() for key in values.keys()]
+        return [
+            key.replace("_", " ").title().replace(" Iq", " IQ")
+            for key in values.keys()
+        ]
 
     def getSupportedCommands(self) -> list[str]:
         """Get the list of supported commands for this vacuum model.

--- a/custom_components/robovac/vacuums/T2181.py
+++ b/custom_components/robovac/vacuums/T2181.py
@@ -69,6 +69,7 @@ class T2181(RobovacModelDetails):
             "code": 102,
             "values": {
                 "quiet": "Quiet",
+                "standard": "Standard",
                 "turbo": "Turbo",
                 "max": "Max",
             },

--- a/custom_components/robovac/vacuums/T2210.py
+++ b/custom_components/robovac/vacuums/T2210.py
@@ -54,6 +54,7 @@ class T2210(RobovacModelDetails):
         RobovacCommand.FAN_SPEED: {
             "code": 102,
             "values": {
+                "quiet": "Quiet",
                 "standard": "Standard",
                 "turbo": "Turbo",
                 "max": "Max",

--- a/custom_components/robovac/vacuums/T2212.py
+++ b/custom_components/robovac/vacuums/T2212.py
@@ -54,6 +54,7 @@ class T2212(RobovacModelDetails):
         RobovacCommand.FAN_SPEED: {
             "code": 102,
             "values": {
+                "quiet": "Quiet",
                 "standard": "Standard",
                 "turbo": "Turbo",
                 "max": "Max",

--- a/custom_components/robovac/vacuums/T2254.py
+++ b/custom_components/robovac/vacuums/T2254.py
@@ -54,10 +54,10 @@ class T2254(RobovacModelDetails):
         RobovacCommand.FAN_SPEED: {
             "code": 102,
             "values": {
+                "quiet": "Quiet",
                 "standard": "Standard",
                 "turbo": "Turbo",
                 "max": "Max",
-                "boost_iq": "Boost_IQ",
             },
         },
         RobovacCommand.LOCATE: {

--- a/custom_components/robovac/vacuums/T2255.py
+++ b/custom_components/robovac/vacuums/T2255.py
@@ -54,10 +54,10 @@ class T2255(RobovacModelDetails):
         RobovacCommand.FAN_SPEED: {
             "code": 102,
             "values": {
+                "quiet": "Quiet",
                 "standard": "Standard",
                 "turbo": "Turbo",
                 "max": "Max",
-                "boost_iq": "Boost_IQ",
             },
         },
         RobovacCommand.LOCATE: {

--- a/custom_components/robovac/vacuums/T2258.py
+++ b/custom_components/robovac/vacuums/T2258.py
@@ -21,7 +21,6 @@ class T2258(RobovacModelDetails):
         | RoboVacEntityFeature.DO_NOT_DISTURB
         | RoboVacEntityFeature.AUTO_RETURN
         | RoboVacEntityFeature.CONSUMABLES
-        | RoboVacEntityFeature.BOOST_IQ
     )
     commands = {
         RobovacCommand.START_PAUSE: {
@@ -48,6 +47,7 @@ class T2258(RobovacModelDetails):
                 "standard": "Standard",
                 "turbo": "Turbo",
                 "max": "Max",
+                "boost_iq": "Boost_IQ",
             },
         },
         RobovacCommand.LOCATE: {

--- a/custom_components/robovac/vacuums/T2270.py
+++ b/custom_components/robovac/vacuums/T2270.py
@@ -49,10 +49,10 @@ class T2270(RobovacModelDetails):
         RobovacCommand.FAN_SPEED: {
             "code": 102,
             "values": {
+                "quiet": "Quiet",
                 "standard": "Standard",
                 "turbo": "Turbo",
                 "max": "Max",
-                "boost_iq": "Boost_IQ",
             },
         },
         RobovacCommand.LOCATE: {

--- a/custom_components/robovac/vacuums/T2272.py
+++ b/custom_components/robovac/vacuums/T2272.py
@@ -53,10 +53,10 @@ class T2272(RobovacModelDetails):
         RobovacCommand.FAN_SPEED: {
             "code": 102,
             "values": {
+                "quiet": "Quiet",
                 "standard": "Standard",
                 "turbo": "Turbo",
                 "max": "Max",
-                "boost_iq": "Boost_IQ",
             },
         },
         RobovacCommand.LOCATE: {

--- a/custom_components/robovac/vacuums/T2273.py
+++ b/custom_components/robovac/vacuums/T2273.py
@@ -54,10 +54,10 @@ class T2273(RobovacModelDetails):
         RobovacCommand.FAN_SPEED: {
             "code": 102,
             "values": {
+                "quiet": "Quiet",
                 "standard": "Standard",
                 "turbo": "Turbo",
                 "max": "Max",
-                "boost_iq": "Boost_IQ",
             },
         },
         RobovacCommand.LOCATE: {

--- a/custom_components/robovac/vacuums/T2276.py
+++ b/custom_components/robovac/vacuums/T2276.py
@@ -58,6 +58,7 @@ class T2276(RobovacModelDetails):
                 "pure": "Quiet",
                 "standard": "Standard",
                 "turbo": "Turbo",
+                "max": "Max",
                 "boost": "Boost",
             },
         },

--- a/custom_components/robovac/vacuums/T2351.py
+++ b/custom_components/robovac/vacuums/T2351.py
@@ -40,10 +40,11 @@ class T2351(RobovacModelDetails):
         RobovacCommand.FAN_SPEED: {
             "code": 154,
             "values": {
-                "Standard": "standard",
-                "Boost IQ": "boost_iq",
-                "Max": "max",
-                "Quiet": "Quiet",
+                "quiet": "Quiet",
+                "standard": "standard",
+                "turbo": "turbo",
+                "max": "max",
+                "boost_iq": "boost_iq",
             },
         },
         RobovacCommand.LOCATE: {"code": 153, "values": {"locate": True}},

--- a/scripts/analyze_eufy_support_pdfs.py
+++ b/scripts/analyze_eufy_support_pdfs.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Analyze cached eufy support PDFs for model names and documented features."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_CACHE_DIR = Path(".cache/eufy-support-pdfs")
+
+CLEAN_MODE_PATTERNS = {
+    "auto": r"\bAuto[- ]cleaning mode\b|\bAuto cleaning\b",
+    "spot": r"\bSpot[- ]cleaning mode\b|\bSpot cleaning\b",
+    "edge": r"\bEdge[- ]cleaning mode\b|\bEdge cleaning\b",
+    "single_room": r"\b(?:Single|Small) Room(?:[- ]cleaning)? mode\b",
+    "manual": r"\bManual[- ]cleaning mode\b",
+}
+
+SUCTION_PATTERNS = {
+    "quiet": r"\bQuiet\b",
+    "pure": r"\bPure\b",
+    "standard": r"\bStandard\b",
+    "turbo": r"\bTurbo\b",
+    "max": r"\bMax(?:imum)?\b",
+    "boost_iq": r"\bBoost\s*IQ\b|\bBoostIQ\b",
+}
+
+FEATURE_PATTERNS = {
+    "boost_iq": r"\bBoost\s*IQ\b|\bBoostIQ\b",
+    "mopping": r"\bMopping System\b|\bWater Tank\b|\bmopping mode\b",
+    "boundary_strip": r"\bBoundary Strip\b",
+    "room_cleaning": r"\broom cleaning\b|\bRoom(?:s)?\b",
+    "zone_cleaning": r"\bzone cleaning\b|\bNo-Go Zone\b|\bvirtual boundary\b",
+    "map": r"\bMap\b|\bmapping\b",
+    "find_robot": r"\bFind My Robot\b|\bFind Robot\b",
+    "scheduling": r"\bSchedule Cleaning\b|\bscheduled cleaning\b",
+    "auto_empty": r"\bAuto[- ]Empty\b|\bself-empty\b",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--cache-dir",
+        type=Path,
+        default=DEFAULT_CACHE_DIR,
+        help=f"cache directory (default: {DEFAULT_CACHE_DIR})",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="write JSON report to this path",
+    )
+    return parser.parse_args()
+
+
+def load_manifest(cache_dir: Path) -> dict[str, Any]:
+    """Load the PDF cache manifest."""
+    manifest_path = cache_dir / "manifest.json"
+    if not manifest_path.exists():
+        raise RuntimeError(f"cache manifest not found: {manifest_path}")
+    return json.loads(manifest_path.read_text())
+
+
+def extract_text(pdf_path: Path) -> str:
+    """Extract text from a PDF file."""
+    try:
+        from pypdf import PdfReader
+    except ImportError as err:
+        raise RuntimeError(
+            "pypdf is required for PDF analysis. Run with "
+            "`uv run --with pypdf python scripts/analyze_eufy_support_pdfs.py`."
+        ) from err
+
+    reader = PdfReader(pdf_path)
+    return "\n".join(page.extract_text() or "" for page in reader.pages)
+
+
+def clean_text(text: str) -> str:
+    """Normalize whitespace in extracted PDF text."""
+    return re.sub(r"\s+", " ", text)
+
+
+def find_keys(text: str, patterns: dict[str, str]) -> list[str]:
+    """Return pattern keys found in text."""
+    return [
+        key
+        for key, pattern in patterns.items()
+        if re.search(pattern, text, flags=re.IGNORECASE)
+    ]
+
+
+def parse_supported_models(path: Path) -> dict[str, str]:
+    """Parse site_docs/supported-models.md into model-code friendly names."""
+    model_names: dict[str, str] = {}
+    row_pattern = re.compile(r"^\|\s*(T\d+)\s*\|\s*([^|]+?)\s*\|")
+    for line in path.read_text().splitlines():
+        match = row_pattern.match(line)
+        if match:
+            model_names[match.group(1)] = match.group(2).strip()
+    return model_names
+
+
+def mentioned_model_codes(text: str) -> list[str]:
+    """Return T-model codes mentioned in extracted PDF text."""
+    return sorted(set(re.findall(r"\bT\d{4}\b", text)))
+
+
+def analyze_product(product: dict[str, Any]) -> dict[str, Any]:
+    """Analyze cached PDFs for one product."""
+    combined_text = ""
+    analyzed_downloads: list[dict[str, Any]] = []
+    for download in product.get("downloads") or []:
+        cache = download.get("cache") or {}
+        path = cache.get("path")
+        if not path:
+            continue
+
+        pdf_path = Path(path)
+        if not pdf_path.exists():
+            analyzed_downloads.append(
+                {
+                    "name": download.get("name"),
+                    "path": path,
+                    "error": "cached PDF missing",
+                }
+            )
+            continue
+
+        try:
+            text = clean_text(extract_text(pdf_path))
+        except Exception as exc:  # noqa: BLE001 - keep the cache audit moving.
+            analyzed_downloads.append(
+                {
+                    "name": download.get("name"),
+                    "path": path,
+                    "error": str(exc),
+                }
+            )
+            continue
+
+        combined_text += " " + text
+        analyzed_downloads.append(
+            {
+                "name": download.get("name"),
+                "path": path,
+                "model_codes": mentioned_model_codes(text),
+                "clean_modes": find_keys(text, CLEAN_MODE_PATTERNS),
+                "suction_levels": find_keys(text, SUCTION_PATTERNS),
+                "features": find_keys(text, FEATURE_PATTERNS),
+                "supported_functions": find_keys(text, FEATURE_PATTERNS),
+            }
+        )
+
+    combined_text = clean_text(combined_text)
+    return {
+        "pn": product["pn"],
+        "friendly_name": product["name"],
+        "series": product.get("series"),
+        "support_url": product.get("url"),
+        "manual_count": len(product.get("downloads") or []),
+        "documented_model_codes": mentioned_model_codes(combined_text),
+        "clean_modes": find_keys(combined_text, CLEAN_MODE_PATTERNS),
+        "suction_levels": find_keys(combined_text, SUCTION_PATTERNS),
+        "features": find_keys(combined_text, FEATURE_PATTERNS),
+        "supported_functions": find_keys(combined_text, FEATURE_PATTERNS),
+        "downloads": analyzed_downloads,
+    }
+
+
+def build_report(cache_dir: Path) -> dict[str, Any]:
+    """Build the eufy support PDF analysis report."""
+    manifest = load_manifest(cache_dir)
+    site_docs_names = parse_supported_models(Path("site_docs/supported-models.md"))
+
+    products = [analyze_product(product) for product in manifest["products"]]
+    support_names = {
+        product["pn"]: product["friendly_name"]
+        for product in products
+        if product.get("friendly_name")
+    }
+
+    supported_name_mismatches = []
+    for model_code, docs_name in sorted(site_docs_names.items()):
+        support_name = support_names.get(model_code)
+        if support_name is not None and docs_name != support_name:
+            supported_name_mismatches.append(
+                {
+                    "model_code": model_code,
+                    "supported_models_name": docs_name,
+                    "eufy_support_name": support_name,
+                }
+            )
+
+    products_by_manual: dict[str, list[str]] = defaultdict(list)
+    for product in products:
+        for download in product["downloads"]:
+            path = download.get("path")
+            if path:
+                products_by_manual[path].append(product["pn"])
+
+    return {
+        "cache_manifest": str(cache_dir / "manifest.json"),
+        "product_count": len(products),
+        "products": products,
+        "supported_name_mismatches": supported_name_mismatches,
+        "products_without_primary_manual": [
+            {
+                "pn": product["pn"],
+                "friendly_name": product["friendly_name"],
+            }
+            for product in products
+            if product["manual_count"] == 0
+        ],
+        "shared_manuals": {
+            path: sorted(model_codes)
+            for path, model_codes in sorted(products_by_manual.items())
+            if len(model_codes) > 1
+        },
+    }
+
+
+def main() -> int:
+    """Run the analysis."""
+    args = parse_args()
+    report = build_report(args.cache_dir)
+    output = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(output)
+        print(f"Wrote {args.output}")
+    else:
+        print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:  # noqa: BLE001 - CLI should print a concise failure.
+        print(f"error: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/analyze_eufy_support_pdfs.py
+++ b/scripts/analyze_eufy_support_pdfs.py
@@ -155,7 +155,6 @@ def analyze_product(product: dict[str, Any]) -> dict[str, Any]:
                 "clean_modes": find_keys(text, CLEAN_MODE_PATTERNS),
                 "suction_levels": find_keys(text, SUCTION_PATTERNS),
                 "features": find_keys(text, FEATURE_PATTERNS),
-                "supported_functions": find_keys(text, FEATURE_PATTERNS),
             }
         )
 
@@ -170,7 +169,6 @@ def analyze_product(product: dict[str, Any]) -> dict[str, Any]:
         "clean_modes": find_keys(combined_text, CLEAN_MODE_PATTERNS),
         "suction_levels": find_keys(combined_text, SUCTION_PATTERNS),
         "features": find_keys(combined_text, FEATURE_PATTERNS),
-        "supported_functions": find_keys(combined_text, FEATURE_PATTERNS),
         "downloads": analyzed_downloads,
     }
 

--- a/scripts/cache_eufy_support_pdfs.py
+++ b/scripts/cache_eufy_support_pdfs.py
@@ -90,6 +90,7 @@ def load_products() -> list[Product]:
     match = re.search(
         r'<script id="__NEXT_DATA__" type="application/json">(.*?)</script>',
         index_html,
+        flags=re.DOTALL,
     )
     if match is None:
         raise RuntimeError("could not find __NEXT_DATA__ in eufy manual index")
@@ -153,8 +154,8 @@ def collect_downloads(products: list[Product], timeout_ms: int, headless: bool) 
         page.set_default_timeout(timeout_ms)
 
         for product in products:
-            page.goto(product.url, wait_until="load")
             try:
+                page.goto(product.url, wait_until="load")
                 page.wait_for_function(
                     """
                     () => {

--- a/site_docs/supported-models.md
+++ b/site_docs/supported-models.md
@@ -4,49 +4,49 @@ This page lists all currently supported Eufy RoboVac models.
 
 ## Model Compatibility Table
 
-| Model Code | Friendly Name        | Protocol |
-|------------|----------------------|----------|
-| T1250      | RoboVac G40          | 3.3      |
-| T2080      | RoboVac S1 Pro       | 3.4      |
-| T2103      | RoboVac 11S          | 3.3      |
-| T2117      | RoboVac 35C          | 3.3      |
-| T2118      | RoboVac 30C          | 3.3      |
-| T2119      | RoboVac 11S Plus     | 3.3      |
-| T2120      | RoboVac 15C          | 3.3      |
-| T2123      | RoboVac 25C          | 3.3      |
-| T2128      | RoboVac 15C Max      | 3.3      |
-| T2130      | RoboVac 30C Max      | 3.3      |
-| T2132      | RoboVac 25C Max      | 3.3      |
-| T2150      | RoboVac G10 Hybrid   | 3.3      |
-| T2181      | RoboVac LR30 Hybrid+ | 3.3      |
-| T2190      | RoboVac L70 Hybrid   | 3.3      |
-| T2192      | RoboVac LR20         | 3.3      |
-| T2193      | RoboVac LR30 Hybrid  | 3.3      |
-| T2194      | RoboVac L35 Hybrid   | 3.4      |
-| T2210      | eufy Clean G50       | 3.3      |
-| T2212      | eufy Clean G50 Hybrid | 3.3     |
-| T2250      | RoboVac G30          | 3.3      |
-| T2251      | RoboVac G30 Edge     | 3.3      |
-| T2252      | RoboVac G30 Verge    | 3.3      |
-| T2253      | RoboVac G30 Hybrid   | 3.3      |
-| T2254      | eufy Clean G35       | 3.3      |
-| T2255      | eufy Clean G40       | 3.3      |
-| T2258      | RoboVac G20 Hybrid   | 3.3      |
-| T2259      | RoboVac G32 Pro      | 3.3      |
-| T2261      | RoboVac X8 Hybrid    | 3.3      |
-| T2262      | RoboVac X8           | 3.3      |
-| T2267      | eufy Clean L60       | 3.4      |
-| T2268      | eufy Clean L60 Hybrid | 3.4     |
-| T2270      | RoboVac G35+         | 3.3      |
-| T2272      | RoboVac G40+         | 3.3      |
-| T2273      | RoboVac G40 Hybrid+  | 3.3      |
-| T2275      | eufy Clean L50 SES   | 3.4      |
-| T2276      | eufy Clean X8 Pro SES | 3.4     |
-| T2277      | eufy Clean L60 SES   | 3.4      |
-| T2278      | eufy Clean L60 Hybrid SES | 3.4 |
-| T2280      | eufy Omni C20        | 3.4      |
-| T2320      | eufy Clean X9 Pro    | 3.3      |
-| T2351      | eufy Clean X10 Pro Omni | 3.4   |
+| Model Code | Friendly Name               | Protocol |
+|------------|-----------------------------|----------|
+| T1250      | RoboVac G40                 | 3.3      |
+| T2080      | RoboVac S1 Pro              | 3.4      |
+| T2103      | RoboVac 11S                 | 3.3      |
+| T2117      | RoboVac 35C                 | 3.3      |
+| T2118      | RoboVac 30C                 | 3.3      |
+| T2119      | RoboVac 11S Plus            | 3.3      |
+| T2120      | RoboVac 15C                 | 3.3      |
+| T2123      | RoboVac 25C                 | 3.3      |
+| T2128      | RoboVac 15C Max             | 3.3      |
+| T2130      | RoboVac 30C Max             | 3.3      |
+| T2132      | RoboVac 25C Max             | 3.3      |
+| T2150      | RoboVac G10 Hybrid          | 3.3      |
+| T2181      | RoboVac LR30 Hybrid+        | 3.3      |
+| T2190      | RoboVac L70 Hybrid          | 3.3      |
+| T2192      | RoboVac LR20                | 3.3      |
+| T2193      | RoboVac LR30 Hybrid         | 3.3      |
+| T2194      | RoboVac L35 Hybrid          | 3.4      |
+| T2210      | eufy Clean G50              | 3.3      |
+| T2212      | eufy Clean G50 Hybrid       | 3.3      |
+| T2250      | RoboVac G30                 | 3.3      |
+| T2251      | RoboVac G30 Edge            | 3.3      |
+| T2252      | RoboVac G30 Verge           | 3.3      |
+| T2253      | RoboVac G30 Hybrid          | 3.3      |
+| T2254      | eufy Clean G35              | 3.3      |
+| T2255      | eufy Clean G40              | 3.3      |
+| T2258      | RoboVac G20 Hybrid          | 3.3      |
+| T2259      | RoboVac G32 Pro             | 3.3      |
+| T2261      | RoboVac X8 Hybrid           | 3.3      |
+| T2262      | RoboVac X8                  | 3.3      |
+| T2267      | eufy Clean L60              | 3.4      |
+| T2268      | eufy Clean L60 Hybrid       | 3.4      |
+| T2270      | RoboVac G35+                | 3.3      |
+| T2272      | RoboVac G40+                | 3.3      |
+| T2273      | RoboVac G40 Hybrid+         | 3.3      |
+| T2275      | eufy Clean L50 SES          | 3.4      |
+| T2276      | eufy Clean X8 Pro SES       | 3.4      |
+| T2277      | eufy Clean L60 SES          | 3.4      |
+| T2278      | eufy Clean L60 Hybrid SES   | 3.4      |
+| T2280      | eufy Omni C20               | 3.4      |
+| T2320      | eufy Clean X9 Pro           | 3.3      |
+| T2351      | eufy Clean X10 Pro Omni     | 3.4      |
 
 ## Model Series
 

--- a/site_docs/supported-models.md
+++ b/site_docs/supported-models.md
@@ -11,18 +11,20 @@ This page lists all currently supported Eufy RoboVac models.
 | T2103      | RoboVac 11S          | 3.3      |
 | T2117      | RoboVac 35C          | 3.3      |
 | T2118      | RoboVac 30C          | 3.3      |
-| T2119      | RoboVac 11S Max      | 3.3      |
+| T2119      | RoboVac 11S Plus     | 3.3      |
 | T2120      | RoboVac 15C          | 3.3      |
 | T2123      | RoboVac 25C          | 3.3      |
 | T2128      | RoboVac 15C Max      | 3.3      |
 | T2130      | RoboVac 30C Max      | 3.3      |
 | T2132      | RoboVac 25C Max      | 3.3      |
 | T2150      | RoboVac G10 Hybrid   | 3.3      |
-| T2181      | RoboVac G20          | 3.3      |
-| T2190      | RoboVac G30          | 3.3      |
-| T2192      | RoboVac G30 Edge     | 3.3      |
-| T2193      | RoboVac G30 Verge    | 3.3      |
+| T2181      | RoboVac LR30 Hybrid+ | 3.3      |
+| T2190      | RoboVac L70 Hybrid   | 3.3      |
+| T2192      | RoboVac LR20         | 3.3      |
+| T2193      | RoboVac LR30 Hybrid  | 3.3      |
 | T2194      | RoboVac L35 Hybrid   | 3.4      |
+| T2210      | eufy Clean G50       | 3.3      |
+| T2212      | eufy Clean G50 Hybrid | 3.3     |
 | T2250      | RoboVac G30          | 3.3      |
 | T2251      | RoboVac G30 Edge     | 3.3      |
 | T2252      | RoboVac G30 Verge    | 3.3      |
@@ -30,20 +32,21 @@ This page lists all currently supported Eufy RoboVac models.
 | T2254      | eufy Clean G35       | 3.3      |
 | T2255      | eufy Clean G40       | 3.3      |
 | T2258      | RoboVac G20 Hybrid   | 3.3      |
-| T2259      | RoboVac G40+         | 3.3      |
-| T2261      | RoboVac X8           | 3.3      |
-| T2262      | RoboVac X8 Hybrid    | 3.3      |
-| T2267      | RoboVac LR30 Hybrid  | 3.4      |
-| T2268      | RoboVac LR30 Hybrid+ | 3.4      |
-| T2270      | RoboVac G32 Pro      | 3.3      |
-| T2272      | RoboVac G20          | 3.3      |
-| T2273      | RoboVac G30          | 3.3      |
-| T2275      | RoboVac L35 Hybrid   | 3.4      |
-| T2276      | RoboVac L35 Hybrid+  | 3.4      |
+| T2259      | RoboVac G32 Pro      | 3.3      |
+| T2261      | RoboVac X8 Hybrid    | 3.3      |
+| T2262      | RoboVac X8           | 3.3      |
+| T2267      | eufy Clean L60       | 3.4      |
+| T2268      | eufy Clean L60 Hybrid | 3.4     |
+| T2270      | RoboVac G35+         | 3.3      |
+| T2272      | RoboVac G40+         | 3.3      |
+| T2273      | RoboVac G40 Hybrid+  | 3.3      |
+| T2275      | eufy Clean L50 SES   | 3.4      |
+| T2276      | eufy Clean X8 Pro SES | 3.4     |
 | T2277      | eufy Clean L60 SES   | 3.4      |
-| T2278      | RoboVac G40+         | 3.4      |
-| T2280      | RoboVac G40 Hybrid+  | 3.4      |
+| T2278      | eufy Clean L60 Hybrid SES | 3.4 |
+| T2280      | eufy Omni C20        | 3.4      |
 | T2320      | eufy Clean X9 Pro    | 3.3      |
+| T2351      | eufy Clean X10 Pro Omni | 3.4   |
 
 ## Model Series
 
@@ -52,22 +55,33 @@ series, it may work with an existing configuration.
 
 ### G Series (Basic)
 
-- **G20**: T2181, T2258, T2272
-- **G30**: T2190, T2250, T2251, T2252, T2253, T2273
-- **G32**: T2270
-- **G35**: T2254
-- **G40**: T1250, T2255, T2259, T2277, T2278, T2280
+- **G10 Hybrid**: T2150
+- **G20**: T2258
+- **G30**: T2250, T2251, T2252, T2253
+- **G32**: T2259
+- **G35**: T2254, T2270
+- **G40**: T1250, T2255, T2272, T2273
+- **G50**: T2210, T2212
 
 ### X Series (Premium)
 
 - **X8**: T2261, T2262
+- **X8 Pro**: T2276
 - **X9 Pro**: T2320
+- **X10 Pro Omni**: T2351
 
 ### L Series (Advanced)
 
-- **L35**: T2194, T2275, T2276
-- **LR30**: T2267, T2268
-- **L60**: T2277
+- **L35**: T2194
+- **L50**: T2275
+- **L60**: T2267, T2268, T2277, T2278
+- **L70**: T2190
+- **LR20**: T2192
+- **LR30**: T2181, T2193
+
+### Omni Series
+
+- **C20**: T2280
 
 ### Classic Series
 
@@ -77,9 +91,8 @@ series, it may work with an existing configuration.
 - **30C**: T2118, T2130
 - **35C**: T2117
 
-### Hybrid Models
+### Other Models
 
-- **G10 Hybrid**: T2150
 - **S1 Pro**: T2080
 
 ## Don't See Your Model?

--- a/tests/test_vacuum/test_documented_fan_speed_mappings.py
+++ b/tests/test_vacuum/test_documented_fan_speed_mappings.py
@@ -1,0 +1,119 @@
+"""Tests for fan-speed values audited against cached eufy manuals."""
+
+import pytest
+from unittest.mock import patch
+
+from custom_components.robovac.robovac import RoboVac
+from custom_components.robovac.vacuums.base import RobovacCommand
+
+
+@pytest.mark.parametrize(
+    ("model_code", "expected_values"),
+    [
+        (
+            "T2181",
+            {
+                "quiet": "Quiet",
+                "standard": "Standard",
+                "turbo": "Turbo",
+                "max": "Max",
+            },
+        ),
+        (
+            "T2210",
+            {
+                "quiet": "Quiet",
+                "standard": "Standard",
+                "turbo": "Turbo",
+                "max": "Max",
+                "boost_iq": "Boost_IQ",
+            },
+        ),
+        (
+            "T2212",
+            {
+                "quiet": "Quiet",
+                "standard": "Standard",
+                "turbo": "Turbo",
+                "max": "Max",
+                "boost_iq": "Boost_IQ",
+            },
+        ),
+        (
+            "T2254",
+            {
+                "quiet": "Quiet",
+                "standard": "Standard",
+                "turbo": "Turbo",
+                "max": "Max",
+            },
+        ),
+        (
+            "T2255",
+            {
+                "quiet": "Quiet",
+                "standard": "Standard",
+                "turbo": "Turbo",
+                "max": "Max",
+            },
+        ),
+        (
+            "T2270",
+            {
+                "quiet": "Quiet",
+                "standard": "Standard",
+                "turbo": "Turbo",
+                "max": "Max",
+            },
+        ),
+        (
+            "T2272",
+            {
+                "quiet": "Quiet",
+                "standard": "Standard",
+                "turbo": "Turbo",
+                "max": "Max",
+            },
+        ),
+        (
+            "T2273",
+            {
+                "quiet": "Quiet",
+                "standard": "Standard",
+                "turbo": "Turbo",
+                "max": "Max",
+            },
+        ),
+        (
+            "T2276",
+            {
+                "pure": "Quiet",
+                "standard": "Standard",
+                "turbo": "Turbo",
+                "max": "Max",
+                "boost": "Boost",
+            },
+        ),
+        (
+            "T2351",
+            {
+                "quiet": "Quiet",
+                "standard": "standard",
+                "turbo": "turbo",
+                "max": "max",
+                "boost_iq": "boost_iq",
+            },
+        ),
+    ],
+)
+def test_documented_fan_speed_values(model_code: str, expected_values: dict[str, str]) -> None:
+    """Test fan speeds documented in eufy manuals are exposed by model mappings."""
+    with patch("custom_components.robovac.robovac.TuyaDevice.__init__", return_value=None):
+        robovac = RoboVac(
+            model_code=model_code,
+            device_id="test_id",
+            host="192.168.1.100",
+            local_key="test_key",
+        )
+
+    assert robovac.model_details.commands[RobovacCommand.FAN_SPEED]["values"] == expected_values

--- a/tests/test_vacuum/test_robovac.py
+++ b/tests/test_vacuum/test_robovac.py
@@ -170,7 +170,7 @@ def test_get_fan_speeds() -> None:
             # Model code, expected fan speeds, and mock dictionary
             (
                 "T2118",
-                ["No Suction", "Standard", "Boost Iq", "Max"],
+                ["No Suction", "Standard", "Boost IQ", "Max"],
                 {
                     "no_suction": "No_suction",
                     "standard": "Standard",
@@ -180,7 +180,7 @@ def test_get_fan_speeds() -> None:
             ),
             (
                 "T2250",
-                ["Standard", "Turbo", "Max", "Boost Iq"],
+                ["Standard", "Turbo", "Max", "Boost IQ"],
                 {
                     "standard": "Standard",
                     "turbo": "Turbo",

--- a/tests/test_vacuum/test_t2254_command_mappings.py
+++ b/tests/test_vacuum/test_t2254_command_mappings.py
@@ -43,10 +43,12 @@ def test_t2254_mode_case_insensitive(mock_t2254_robovac) -> None:
 
 def test_t2254_fan_speed_command_values(mock_t2254_robovac) -> None:
     """Test T2254 FAN_SPEED value mapping."""
+    assert mock_t2254_robovac.getRoboVacCommandValue(RobovacCommand.FAN_SPEED, "quiet") == "Quiet"
     assert mock_t2254_robovac.getRoboVacCommandValue(RobovacCommand.FAN_SPEED, "standard") == "Standard"
     assert mock_t2254_robovac.getRoboVacCommandValue(RobovacCommand.FAN_SPEED, "turbo") == "Turbo"
     assert mock_t2254_robovac.getRoboVacCommandValue(RobovacCommand.FAN_SPEED, "max") == "Max"
-    assert mock_t2254_robovac.getRoboVacCommandValue(RobovacCommand.FAN_SPEED, "boost_iq") == "Boost_IQ"
+    values = mock_t2254_robovac.model_details.commands[RobovacCommand.FAN_SPEED]["values"]
+    assert "boost_iq" not in values
     assert mock_t2254_robovac.getRoboVacCommandValue(RobovacCommand.FAN_SPEED, "unknown") == "unknown"
 
 

--- a/tests/test_vacuum/test_t2255_command_mappings.py
+++ b/tests/test_vacuum/test_t2255_command_mappings.py
@@ -43,10 +43,12 @@ def test_t2255_mode_case_insensitive(mock_t2255_robovac) -> None:
 
 def test_t2255_fan_speed_command_values(mock_t2255_robovac) -> None:
     """Test T2255 FAN_SPEED value mapping."""
+    assert mock_t2255_robovac.getRoboVacCommandValue(RobovacCommand.FAN_SPEED, "quiet") == "Quiet"
     assert mock_t2255_robovac.getRoboVacCommandValue(RobovacCommand.FAN_SPEED, "standard") == "Standard"
     assert mock_t2255_robovac.getRoboVacCommandValue(RobovacCommand.FAN_SPEED, "turbo") == "Turbo"
     assert mock_t2255_robovac.getRoboVacCommandValue(RobovacCommand.FAN_SPEED, "max") == "Max"
-    assert mock_t2255_robovac.getRoboVacCommandValue(RobovacCommand.FAN_SPEED, "boost_iq") == "Boost_IQ"
+    values = mock_t2255_robovac.model_details.commands[RobovacCommand.FAN_SPEED]["values"]
+    assert "boost_iq" not in values
     assert mock_t2255_robovac.getRoboVacCommandValue(RobovacCommand.FAN_SPEED, "unknown") == "unknown"
 
 

--- a/tests/test_vacuum/test_t2258_command_mappings.py
+++ b/tests/test_vacuum/test_t2258_command_mappings.py
@@ -4,10 +4,7 @@ import pytest
 from unittest.mock import patch
 
 from custom_components.robovac.robovac import RoboVac
-from custom_components.robovac.vacuums.base import (
-    RoboVacEntityFeature,
-    RobovacCommand,
-)
+from custom_components.robovac.vacuums.base import RobovacCommand
 
 
 @pytest.fixture
@@ -52,17 +49,15 @@ def test_t2258_uses_documented_suction_levels(mock_t2258_robovac) -> None:
         "standard": "Standard",
         "turbo": "Turbo",
         "max": "Max",
+        "boost_iq": "Boost_IQ",
     }
     assert mock_t2258_robovac.getRoboVacCommandValue(RobovacCommand.FAN_SPEED, "quiet") == "Quiet"
     assert mock_t2258_robovac.getRoboVacCommandValue(RobovacCommand.FAN_SPEED, "standard") == "Standard"
     assert mock_t2258_robovac.getRoboVacCommandValue(RobovacCommand.FAN_SPEED, "turbo") == "Turbo"
     assert mock_t2258_robovac.getRoboVacCommandValue(RobovacCommand.FAN_SPEED, "max") == "Max"
-    assert "boost_iq" not in values
-
-
-def test_t2258_exposes_boost_iq_as_separate_setting(mock_t2258_robovac) -> None:
-    """Test T2258 follows documented BoostIQ feature behavior."""
-    assert mock_t2258_robovac.model_details.robovac_features & RoboVacEntityFeature.BOOST_IQ
+    assert mock_t2258_robovac.getRoboVacCommandValue(
+        RobovacCommand.FAN_SPEED, "boost_iq"
+    ) == "Boost_IQ"
 
 
 def test_t2258_does_not_expose_direction_command(mock_t2258_robovac) -> None:
@@ -84,6 +79,6 @@ def test_t2258_model_has_basic_commands(mock_t2258_robovac) -> None:
     assert RobovacCommand.ERROR in commands
 
 
-def test_t2258_does_not_override_default_boost_iq_dps_code(mock_t2258_robovac) -> None:
-    """Test T2258 relies on the default BoostIQ DPS fallback."""
-    assert mock_t2258_robovac.getDpsCodes().get("BOOST_IQ") is None
+def test_t2258_does_not_expose_boost_iq_setting_command(mock_t2258_robovac) -> None:
+    """Test T2258 exposes BoostIQ as fan speed, not a boolean setting."""
+    assert RobovacCommand.BOOST_IQ not in mock_t2258_robovac.model_details.commands

--- a/tests/test_vacuum/test_vacuum_commands.py
+++ b/tests/test_vacuum/test_vacuum_commands.py
@@ -512,10 +512,37 @@ async def test_async_send_command_rejects_unsupported_t2258_modes(
 
 
 @pytest.mark.asyncio
-async def test_async_send_command_sends_t2258_boost_iq_setting(
+async def test_async_set_fan_speed_sends_t2258_boost_iq_value(
     mock_vacuum_data,
 ) -> None:
-    """Test T2258 sends documented BoostIQ as a separate setting command."""
+    """Test T2258 sends documented BoostIQ as a fan-speed value."""
+    with patch("custom_components.robovac.robovac.TuyaDevice.__init__", return_value=None):
+        robovac = RoboVac(
+            model_code="T2258",
+            device_id="test_id",
+            host="192.168.1.100",
+            local_key="test_key",
+        )
+    robovac.async_set = AsyncMock(return_value=True)
+    robovac._dps = {}
+    t2258_data = {
+        **mock_vacuum_data,
+        CONF_MODEL: "T2258",
+        CONF_DESCRIPTION: "RoboVac G20 Hybrid",
+    }
+
+    with patch("custom_components.robovac.vacuum.RoboVac", return_value=robovac):
+        entity = RoboVacEntity(t2258_data)
+
+    await entity.async_set_fan_speed("Boost IQ")
+    robovac.async_set.assert_called_once_with({"102": "Boost_IQ"})
+
+
+@pytest.mark.asyncio
+async def test_async_send_command_rejects_t2258_boost_iq_setting(
+    mock_vacuum_data,
+) -> None:
+    """Test T2258 does not send an unverified BoostIQ setting command."""
     with patch("custom_components.robovac.robovac.TuyaDevice.__init__", return_value=None):
         robovac = RoboVac(
             model_code="T2258",
@@ -533,17 +560,10 @@ async def test_async_send_command_sends_t2258_boost_iq_setting(
     with patch("custom_components.robovac.vacuum.RoboVac", return_value=robovac):
         entity = RoboVacEntity(t2258_data)
 
-    assert entity.get_dps_code("BOOST_IQ") == "118"
+    with pytest.raises(HomeAssistantError, match="does not support BoostIQ setting"):
+        await entity.async_send_command("boostIQ")
 
-    entity._attr_boost_iq = False
-    await entity.async_send_command("boostIQ")
-    robovac.async_set.assert_called_once_with({"118": True})
-
-    robovac.async_set.reset_mock()
-
-    entity._attr_boost_iq = True
-    await entity.async_send_command("boostIQ")
-    robovac.async_set.assert_called_once_with({"118": False})
+    robovac.async_set.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a local PDF analysis task for the ignored eufy support cache
- redo the T2258 BoostIQ behavior from damacus/robovac#424 using the cached eufy manuals: Auto/Spot clean modes, Quiet/Standard/Turbo/Max/BoostIQ fan speeds
- update supported-model docs to match eufy support/manual names and fix stale series grouping
- audit PDF-documented fan speeds against registered model mappings and fix simple enum gaps

## PDF findings
- T2258 manual documents model code T2258, clean modes Auto and Spot, and BoostIQ support
- G30 Edge docs also show BoostIQ support, matching the existing fan-speed value pattern
- T2254/T2255 share the G35/G40 manual; docs keep T2254 as eufy Clean G35 and T2255 as eufy Clean G40
- G35/G40-family manuals document Quiet/Standard/Turbo/Max and do not document BoostIQ, so those mappings now remove the old BoostIQ fan-speed value
- T2181, T2210, T2212, T2276, and T2351 were missing documented fan-speed values and now expose them
- one cached RoboVac 15T manual is malformed and is recorded as an extraction error instead of aborting the report

## Remaining audit items
- T2280 fan speed is an encoded payload, so its PDF-documented levels need a real DPS/protobuf dump before changing the mapping
- T2320 and T2351 PDF spot-mode entries need model-specific payload confirmation before exposing spot mode

## Tests
- ./.venv/bin/pytest tests/test_vacuum/test_t2258_command_mappings.py tests/test_vacuum/test_vacuum_commands.py -q
- ./.venv/bin/pytest tests/test_vacuum/test_*command_mappings.py tests/test_vacuum/test_vacuum_commands.py -q
- ./.venv/bin/pytest tests/test_vacuum/test_documented_fan_speed_mappings.py tests/test_vacuum/test_*command_mappings.py tests/test_vacuum/test_vacuum_commands.py -q
- uv run flake8 scripts/cache_eufy_support_pdfs.py scripts/analyze_eufy_support_pdfs.py custom_components/robovac/vacuums/T2258.py tests/test_vacuum/test_t2258_command_mappings.py tests/test_vacuum/test_vacuum_commands.py
- uv run flake8 custom_components/robovac/vacuums/T2181.py custom_components/robovac/vacuums/T2210.py custom_components/robovac/vacuums/T2212.py custom_components/robovac/vacuums/T2254.py custom_components/robovac/vacuums/T2255.py custom_components/robovac/vacuums/T2270.py custom_components/robovac/vacuums/T2272.py custom_components/robovac/vacuums/T2273.py custom_components/robovac/vacuums/T2276.py custom_components/robovac/vacuums/T2351.py tests/test_vacuum/test_documented_fan_speed_mappings.py tests/test_vacuum/test_t2254_command_mappings.py tests/test_vacuum/test_t2255_command_mappings.py

Co-authored-by: Phan Khánh <39584844+phankhanhpvk@users.noreply.github.com>