### PR TITLE
fix: send lowercase auto for L35

### DIFF
--- a/custom_components/robovac/vacuums/T2194.py
+++ b/custom_components/robovac/vacuums/T2194.py
@@ -44,7 +44,7 @@ class T2194(RobovacModelDetails):
         RobovacCommand.MODE: {
             "code": 5,
             "values": {
-                "auto": "Auto",
+                "auto": "auto",
                 "small_room": "SmallRoom",
                 "spot": "Spot",
                 "edge": "Edge",

--- a/tests/test_vacuum/test_t2194_command_mappings.py
+++ b/tests/test_vacuum/test_t2194_command_mappings.py
@@ -63,8 +63,12 @@ def test_t2194_fan_speed_command_values(mock_t2194_robovac) -> None:
 
 
 def test_t2194_mode_command_values(mock_t2194_robovac) -> None:
-    """Test T2194 MODE command value mappings."""
-    assert mock_t2194_robovac.getRoboVacCommandValue(RobovacCommand.MODE, "auto") == "Auto"
+    """Test T2194 MODE command value mappings.
+
+    GH-309: L35 Hybrid interprets DPS 5 "Auto" as spot cleaning, so normal
+    cleaning must send lowercase "auto" like the device reports in state.
+    """
+    assert mock_t2194_robovac.getRoboVacCommandValue(RobovacCommand.MODE, "auto") == "auto"
     assert mock_t2194_robovac.getRoboVacCommandValue(RobovacCommand.MODE, "spot") == "Spot"
     assert mock_t2194_robovac.getRoboVacCommandValue(RobovacCommand.MODE, "edge") == "Edge"
 


### PR DESCRIPTION
## Summary
- send lowercase auto mode for T2194 L35 Hybrid normal cleaning
- add regression coverage for the GH-309 mode mapping

## Tests
- ./.venv/bin/pytest tests/test_vacuum/test_t2194_command_mappings.py
- ./.venv/bin/flake8 custom_components/robovac/vacuums/T2194.py tests/test_vacuum/test_t2194_command_mappings.py

Fixes #309
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/robovac/pull/534" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->