### PR TITLE
fix: restore protocol 3.5 DPS fetch

### DIFF
--- a/custom_components/robovac/tuyalocalapi.py
+++ b/custom_components/robovac/tuyalocalapi.py
@@ -1199,15 +1199,19 @@ class TuyaDevice:
 
         This method retrieves the current state of the device.
         """
+        if self.version >= (3, 5):
+            payload_bytes = json.dumps({}).encode("utf-8")
+            message = Message(
+                Message.GET_COMMAND_NEW,
+                payload_bytes,
+                encrypt=True,
+                device=self,
+                expect_response=False,
+            )
+            await self.async_connect()
+            self._queue.append(message)
+            return
         if self.version >= (3, 4):
-            # v3.5 devices reject all known GET/query commands:
-            # - DP_QUERY (0x0a) → "json obj data unvalid"
-            # - DP_QUERY_NEW (0x10) → same
-            # - UPDATEDPS (0x12) → empty ACK, no DPS data (tested with
-            #   valid DPS IDs [2,5,15,101,102,103,104,106] — still empty)
-            #
-            # The only way to get DPS state is via gratuitous updates (0x08)
-            # the device sends after SET commands.  So just stay connected.
             await self.async_connect()
             return
         if self._backoff is True:
@@ -1282,11 +1286,34 @@ class TuyaDevice:
         if self._backoff is True:
             self._LOGGER.debug("Currently in backoff, not adding ping to queue")
         elif self.version >= (3, 5):
-            # v3.5 devices (like T2276) don't support Tuya heartbeats — they
-            # close the TCP connection after receiving any ping, regardless of
-            # format.  Skip heartbeats entirely; the device will naturally EOF
-            # when idle, and process_queue will drive reconnection.
-            pass
+            t = int(time.time())
+            payload = {
+                "protocol": 5,
+                "data": {
+                    "dps": {
+                        "121": base64.b64encode(
+                            json.dumps(
+                                {
+                                    "type": "mapData",
+                                    "id": self.device_id,
+                                    "timestamp": int(time.time() * 1000),
+                                },
+                                separators=(",", ":"),
+                            ).encode("utf-8")
+                        ).decode("utf-8")
+                    }
+                },
+                "t": t,
+            }
+            payload_bytes = json.dumps(payload).encode("utf-8")
+            message = Message(
+                Message.SET_COMMAND_NEW,
+                payload_bytes,
+                encrypt=True,
+                device=self,
+                expect_response=False,
+            )
+            self._queue.append(message)
         else:
             self.last_ping = time.time()
             encrypt = False if self.version < (3, 3) else True

--- a/custom_components/robovac/tuyalocalapi.py
+++ b/custom_components/robovac/tuyalocalapi.py
@@ -1194,12 +1194,48 @@ class TuyaDevice:
         # most vacuum models.
         return {str(k): None for k in [2, 5, 15, 101, 102, 103, 104, 106]}
 
+    def _uses_protocol_35_empty_dps_query(self) -> bool:
+        """Return whether the model uses empty DP_QUERY_NEW for status refresh."""
+        model_details = getattr(self, "model_details", None)
+        return self.version >= (3, 5) and bool(
+            getattr(model_details, "protocol_35_empty_dps_query", False)
+        )
+
+    def _uses_protocol_35_map_data_keepalive(self) -> bool:
+        """Return whether the model uses the DPS 121 mapData keepalive."""
+        model_details = getattr(self, "model_details", None)
+        return self.version >= (3, 5) and bool(
+            getattr(model_details, "protocol_35_map_data_keepalive", False)
+        )
+
+    def _protocol_35_map_data_keepalive_payload(self, now: float) -> bytes:
+        """Build the mobile-app-style DPS 121 keepalive payload."""
+        map_data = {
+            "type": "mapData",
+            "id": self.device_id,
+            "timestamp": int(now * 1000),
+        }
+        payload = {
+            "protocol": 5,
+            "data": {
+                "dps": {
+                    "121": base64.b64encode(
+                        json.dumps(map_data, separators=(",", ":")).encode("utf-8")
+                    ).decode("utf-8")
+                }
+            },
+            "t": int(now),
+        }
+        return json.dumps(payload).encode("utf-8")
+
     async def async_get(self) -> None:
         """Get the current state of the device.
 
         This method retrieves the current state of the device.
         """
-        if self.version >= (3, 5):
+        if self._uses_protocol_35_empty_dps_query():
+            # T2276/X8 Pro SES mirrors the mobile app: after session-key
+            # negotiation, an empty DP_QUERY_NEW prompts the device to push DPS.
             payload_bytes = json.dumps({}).encode("utf-8")
             message = Message(
                 Message.GET_COMMAND_NEW,
@@ -1285,27 +1321,8 @@ class TuyaDevice:
 
         if self._backoff is True:
             self._LOGGER.debug("Currently in backoff, not adding ping to queue")
-        elif self.version >= (3, 5):
-            t = int(time.time())
-            payload = {
-                "protocol": 5,
-                "data": {
-                    "dps": {
-                        "121": base64.b64encode(
-                            json.dumps(
-                                {
-                                    "type": "mapData",
-                                    "id": self.device_id,
-                                    "timestamp": int(time.time() * 1000),
-                                },
-                                separators=(",", ":"),
-                            ).encode("utf-8")
-                        ).decode("utf-8")
-                    }
-                },
-                "t": t,
-            }
-            payload_bytes = json.dumps(payload).encode("utf-8")
+        elif self._uses_protocol_35_map_data_keepalive():
+            payload_bytes = self._protocol_35_map_data_keepalive_payload(time.time())
             message = Message(
                 Message.SET_COMMAND_NEW,
                 payload_bytes,
@@ -1314,6 +1331,10 @@ class TuyaDevice:
                 expect_response=False,
             )
             self._queue.append(message)
+        elif self.version >= (3, 5):
+            # Unknown protocol 3.5 models should not inherit T2276's DPS 121
+            # write until that behavior has been confirmed for the model.
+            pass
         else:
             self.last_ping = time.time()
             encrypt = False if self.version < (3, 3) else True

--- a/custom_components/robovac/vacuums/T2276.py
+++ b/custom_components/robovac/vacuums/T2276.py
@@ -11,6 +11,8 @@ from .base import RoboVacEntityFeature, RobovacCommand, RobovacModelDetails
 
 class T2276(RobovacModelDetails):
     protocol_version = 3.5
+    protocol_35_empty_dps_query = True
+    protocol_35_map_data_keepalive = True
     homeassistant_features = (
         VacuumEntityFeature.FAN_SPEED
         | VacuumEntityFeature.LOCATE

--- a/tests/test_vacuum/test_tuyalocalapi_async_get.py
+++ b/tests/test_vacuum/test_tuyalocalapi_async_get.py
@@ -1,6 +1,8 @@
 """Tests for local Tuya status refresh behavior."""
 
 import asyncio
+import base64
+import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
@@ -63,6 +65,75 @@ async def test_legacy_async_get_skips_status_request_during_backoff() -> None:
     device.async_receive.assert_not_awaited()
     assert device._queue == []
     assert device._listeners == {}
+
+
+@pytest.mark.asyncio
+async def test_protocol_35_async_get_requests_status_with_get_command_new() -> None:
+    """Protocol 3.5 status refresh sends DP_QUERY_NEW with an empty object."""
+    device = TuyaDevice.__new__(TuyaDevice)
+    device.version = (3, 5)
+    device.gateway_id = "test-device"
+    device.device_id = "test-device"
+    device._queue = []
+    device._listeners = {}
+    device._backoff = False
+
+    device.async_connect = AsyncMock()
+    device.async_receive = AsyncMock()
+
+    await device.async_get()
+
+    device.async_connect.assert_awaited_once()
+    device.async_receive.assert_not_awaited()
+    assert len(device._queue) == 1
+    message = device._queue[0]
+    assert message.command == Message.GET_COMMAND_NEW
+    assert json.loads(message.payload.decode("utf-8")) == {}
+    assert message.encrypt is True
+    assert message.expect_response is False
+
+
+@pytest.mark.asyncio
+async def test_protocol_35_ping_queues_map_data_keepalive() -> None:
+    """Protocol 3.5 keepalive mirrors the mobile app map-data control request."""
+    device = TuyaDevice.__new__(TuyaDevice)
+    device.version = (3, 5)
+    device.device_id = "test-device"
+    device._queue = []
+    device._backoff = False
+    device._enabled = True
+    device._LOGGER = MagicMock()
+    device.ping_interval = 55
+
+    def close_scheduled_ping(coro: object) -> MagicMock:
+        close = getattr(coro, "close", None)
+        if close is not None:
+            close()
+        return MagicMock()
+
+    with patch("custom_components.robovac.tuyalocalapi.time.time", return_value=1234.5):
+        with patch("custom_components.robovac.tuyalocalapi.asyncio.sleep", new=AsyncMock()):
+            with patch(
+                "custom_components.robovac.tuyalocalapi.asyncio.create_task",
+                side_effect=close_scheduled_ping,
+            ):
+                await device.async_ping(55)
+
+    assert len(device._queue) == 1
+    message = device._queue[0]
+    assert message.command == Message.SET_COMMAND_NEW
+    assert message.encrypt is True
+    assert message.expect_response is False
+
+    payload = json.loads(message.payload.decode("utf-8"))
+    assert payload["protocol"] == 5
+    assert payload["t"] == 1234
+    map_data = json.loads(base64.b64decode(payload["data"]["dps"]["121"]))
+    assert map_data == {
+        "type": "mapData",
+        "id": "test-device",
+        "timestamp": 1234500,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_vacuum/test_tuyalocalapi_async_get.py
+++ b/tests/test_vacuum/test_tuyalocalapi_async_get.py
@@ -69,8 +69,9 @@ async def test_legacy_async_get_skips_status_request_during_backoff() -> None:
 
 @pytest.mark.asyncio
 async def test_protocol_35_async_get_requests_status_with_get_command_new() -> None:
-    """Protocol 3.5 status refresh sends DP_QUERY_NEW with an empty object."""
+    """Opted-in protocol 3.5 models send DP_QUERY_NEW with an empty object."""
     device = TuyaDevice.__new__(TuyaDevice)
+    device.model_details = SimpleNamespace(protocol_35_empty_dps_query=True)
     device.version = (3, 5)
     device.gateway_id = "test-device"
     device.device_id = "test-device"
@@ -94,9 +95,30 @@ async def test_protocol_35_async_get_requests_status_with_get_command_new() -> N
 
 
 @pytest.mark.asyncio
-async def test_protocol_35_ping_queues_map_data_keepalive() -> None:
-    """Protocol 3.5 keepalive mirrors the mobile app map-data control request."""
+async def test_protocol_35_async_get_without_opt_in_only_connects() -> None:
+    """Protocol 3.5 models do not inherit T2276 status queries by default."""
     device = TuyaDevice.__new__(TuyaDevice)
+    device.model_details = SimpleNamespace()
+    device.version = (3, 5)
+    device._queue = []
+    device._listeners = {}
+    device._backoff = False
+
+    device.async_connect = AsyncMock()
+    device.async_receive = AsyncMock()
+
+    await device.async_get()
+
+    device.async_connect.assert_awaited_once()
+    device.async_receive.assert_not_awaited()
+    assert device._queue == []
+
+
+@pytest.mark.asyncio
+async def test_protocol_35_ping_queues_map_data_keepalive() -> None:
+    """Opted-in protocol 3.5 models mirror the mobile app keepalive request."""
+    device = TuyaDevice.__new__(TuyaDevice)
+    device.model_details = SimpleNamespace(protocol_35_map_data_keepalive=True)
     device.version = (3, 5)
     device.device_id = "test-device"
     device._queue = []
@@ -134,6 +156,35 @@ async def test_protocol_35_ping_queues_map_data_keepalive() -> None:
         "id": "test-device",
         "timestamp": 1234500,
     }
+
+
+@pytest.mark.asyncio
+async def test_protocol_35_ping_without_opt_in_does_not_write_dps_121() -> None:
+    """Protocol 3.5 models do not inherit T2276 map-data writes by default."""
+    device = TuyaDevice.__new__(TuyaDevice)
+    device.model_details = SimpleNamespace()
+    device.version = (3, 5)
+    device.device_id = "test-device"
+    device._queue = []
+    device._backoff = False
+    device._enabled = True
+    device._LOGGER = MagicMock()
+    device.ping_interval = 55
+
+    def close_scheduled_ping(coro: object) -> MagicMock:
+        close = getattr(coro, "close", None)
+        if close is not None:
+            close()
+        return MagicMock()
+
+    with patch("custom_components.robovac.tuyalocalapi.asyncio.sleep", new=AsyncMock()):
+        with patch(
+            "custom_components.robovac.tuyalocalapi.asyncio.create_task",
+            side_effect=close_scheduled_ping,
+        ):
+            await device.async_ping(55)
+
+    assert device._queue == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- request protocol 3.5 DPS state with encrypted GET_COMMAND_NEW and an empty object
- keep protocol 3.5 sessions alive with the mobile-app-style protocol 5 DPS 121 map-data control message
- add regression coverage for protocol 3.5 status refresh and keepalive queueing

Fixes #436

## Tests
- /Users/damacus/.codex/worktrees/6ef2/robovac/.venv/bin/pytest tests/test_vacuum/test_tuyalocalapi_async_get.py tests/test_vacuum/test_protocol_35_message.py tests/test_vacuum/test_protocol_35_cipher.py -q
- /Users/damacus/.codex/worktrees/6ef2/robovac/.venv/bin/flake8 custom_components/robovac/tuyalocalapi.py tests/test_vacuum/test_tuyalocalapi_async_get.py
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/robovac/pull/535" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->