### PR TITLE
fix: keep C10 discovery on Tuya denial

### DIFF
--- a/custom_components/robovac/config_flow.py
+++ b/custom_components/robovac/config_flow.py
@@ -59,7 +59,7 @@ from .countries import (
     get_region_by_phone_code,
 )
 from .eufywebapi import EufyLogon
-from .tuyawebapi import TuyaAPISession
+from .tuyawebapi import TuyaAPIError, TuyaAPISession
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -69,6 +69,29 @@ USER_SCHEMA = vol.Schema(
         vol.Required(CONF_PASSWORD): cv.string,
     }
 )
+
+
+def _is_tuya_permission_denied(error: Exception) -> bool:
+    """Return True when Tuya denied access to a Eufy-discovered device."""
+    if isinstance(error, TuyaAPIError):
+        return error.error_code == "PERMISSION_DENIED"
+    return "PERMISSION_DENIED" in str(error)
+
+
+def _vacuum_details_from_eufy_item(
+    item: dict[str, Any], access_token: str
+) -> dict[str, Any]:
+    """Build config-flow vacuum details from a Eufy device record."""
+    return {
+        CONF_ID: item["id"],
+        CONF_MODEL: item["product"]["product_code"],
+        CONF_NAME: item["alias_name"],
+        CONF_DESCRIPTION: item["name"],
+        CONF_MAC: item["wifi"]["mac"],
+        CONF_IP_ADDRESS: "",
+        CONF_AUTODISCOVERY: True,
+        CONF_ACCESS_TOKEN: access_token,
+    }
 
 
 def get_eufy_vacuums(self: dict[str, Any]) -> requests.Response:
@@ -162,18 +185,28 @@ def get_eufy_vacuums(self: dict[str, Any]) -> requests.Response:
         if item["product"]["appliance"] == "Cleaning":
             try:
                 device = tuya_client.get_device(item["id"])
+                access_token = device["localKey"]
+            except Exception as err:
+                if _is_tuya_permission_denied(err):
+                    _LOGGER.warning(
+                        "Tuya denied access to vacuum %s; keeping Eufy discovery "
+                        "details without a local key",
+                        item["id"],
+                    )
+                    access_token = ""
+                else:
+                    _LOGGER.debug(
+                        "Skipping vacuum {}: found on Eufy but not on Tuya. Eufy details:".format(
+                            item["id"]
+                        )
+                    )
+                    _LOGGER.debug(json.dumps(item, indent=2))
+                    continue
 
-                vac_details = {
-                    CONF_ID: item["id"],
-                    CONF_MODEL: item["product"]["product_code"],
-                    CONF_NAME: item["alias_name"],
-                    CONF_DESCRIPTION: item["name"],
-                    CONF_MAC: item["wifi"]["mac"],
-                    CONF_IP_ADDRESS: "",
-                    CONF_AUTODISCOVERY: True,
-                    CONF_ACCESS_TOKEN: device["localKey"],
-                }
-                self[CONF_VACS][item["id"]] = vac_details
+            try:
+                self[CONF_VACS][item["id"]] = _vacuum_details_from_eufy_item(
+                    item, access_token
+                )
             except Exception:
                 _LOGGER.debug(
                     "Skipping vacuum {}: found on Eufy but not on Tuya. Eufy details:".format(

--- a/custom_components/robovac/config_flow.py
+++ b/custom_components/robovac/config_flow.py
@@ -72,7 +72,7 @@ USER_SCHEMA = vol.Schema(
 
 
 def _is_tuya_permission_denied(error: Exception) -> bool:
-    """Return True when Tuya denied access to a Eufy-discovered device."""
+    """Return True when Tuya denied access to an Eufy-discovered device."""
     if isinstance(error, TuyaAPIError):
         return error.error_code == "PERMISSION_DENIED"
     return "PERMISSION_DENIED" in str(error)
@@ -81,7 +81,7 @@ def _is_tuya_permission_denied(error: Exception) -> bool:
 def _vacuum_details_from_eufy_item(
     item: dict[str, Any], access_token: str
 ) -> dict[str, Any]:
-    """Build config-flow vacuum details from a Eufy device record."""
+    """Build config-flow vacuum details from an Eufy device record."""
     return {
         CONF_ID: item["id"],
         CONF_MODEL: item["product"]["product_code"],

--- a/custom_components/robovac/errors.py
+++ b/custom_components/robovac/errors.py
@@ -2,6 +2,16 @@ ERROR_MESSAGES = {
     "IP_ADDRESS": "IP Address not set",
     "CONNECTION_FAILED": "Connection to the vacuum failed",
     "UNSUPPORTED_MODEL": "This model is not supported",
+    "LOCAL_KEY_UNAVAILABLE": (
+        "Tuya denied access to this vacuum's local key. Re-link the vacuum in "
+        "the Eufy app or check account and region permissions, then reload the "
+        "integration."
+    ),
+    "INVALID_LOCAL_KEY": (
+        "Tuya returned an invalid local key for this vacuum. Re-link the vacuum "
+        "in the Eufy app or check account and region permissions, then reload "
+        "the integration."
+    ),
     "no_error": "None",
     1: "Front bumper stuck",
     2: "Wheel stuck",

--- a/custom_components/robovac/tuyawebapi.py
+++ b/custom_components/robovac/tuyawebapi.py
@@ -117,6 +117,16 @@ DEFAULT_TUYA_QUERY_PARAMS = {
 }
 
 
+class TuyaAPIError(RuntimeError):
+    """Error returned by the Tuya API."""
+
+    def __init__(self, message: str, response: Dict[str, Any]) -> None:
+        """Initialize a Tuya API error from the response payload."""
+        super().__init__(message)
+        self.response = response
+        self.error_code = response.get("errorCode")
+
+
 class TuyaAPISession:
     """Session handler for Tuya API authentication and requests.
 
@@ -282,6 +292,11 @@ class TuyaAPISession:
             raise TypeError(f"Invalid JSON response from API: {str(e)}") from e
 
         if "result" not in response_data:
+            if "errorCode" in response_data:
+                raise TuyaAPIError(
+                    response_data.get("errorMsg", "Tuya API request failed"),
+                    response_data,
+                )
             raise KeyError(
                 f"No 'result' key in the response - the entire response is {response_data}"
             )

--- a/custom_components/robovac/tuyawebapi.py
+++ b/custom_components/robovac/tuyawebapi.py
@@ -124,7 +124,10 @@ class TuyaAPIError(RuntimeError):
         """Initialize a Tuya API error from the response payload."""
         super().__init__(message)
         self.response = response
-        self.error_code = response.get("errorCode")
+        error_code = response.get("errorCode")
+        self.error_code: str | None = (
+            str(error_code) if error_code is not None else None
+        )
 
 
 class TuyaAPISession:
@@ -293,8 +296,10 @@ class TuyaAPISession:
 
         if "result" not in response_data:
             if "errorCode" in response_data:
+                error_code = response_data.get("errorCode")
+                error_msg = response_data.get("errorMsg", "Tuya API request failed")
                 raise TuyaAPIError(
-                    response_data.get("errorMsg", "Tuya API request failed"),
+                    f"{error_code}: {error_msg}",
                     response_data,
                 )
             raise KeyError(

--- a/custom_components/robovac/vacuum.py
+++ b/custom_components/robovac/vacuum.py
@@ -75,7 +75,7 @@ from .proto_decode import (
 )
 from .vacuums.base import RobovacCommand, RoboVacEntityFeature, TuyaCodes, TUYA_CONSUMABLES_CODES
 from .robovac import ModelNotSupportedException, RoboVac
-from .tuyalocalapi import TuyaException
+from .tuyalocalapi import InvalidKey, TuyaException
 from .tuyawebapi import TuyaAPISession
 
 ATTR_BATTERY_ICON = "battery_icon"
@@ -736,33 +736,50 @@ class RoboVacEntity(StateVacuumEntity):
         self._cloud_room_lookup_attempted = False
 
         # Initialize the RoboVac connection
-        try:
-            # Extract model code prefix for device identification
-            model_code_prefix = ""
-            if self.model_code is not None:
-                model_code_prefix = self.model_code[0:5]
-
-            # Create the RoboVac instance
-            self.vacuum = RoboVac(
-                device_id=self.unique_id,
-                host=self.ip_address,
-                local_key=self.access_token,
-                timeout=TIMEOUT,
-                ping_interval=PING_RATE,
-                model_code=model_code_prefix,
-                update_entity_state=self.pushed_update_handler,
-            )
-            _LOGGER.debug(
-                "Initialized RoboVac connection for %s (model: %s)",
-                self._attr_name,
-                self._attr_model_code
-            )
-        except ModelNotSupportedException:
+        if not self.access_token:
             _LOGGER.error(
-                "Model %s is not supported",
-                self._attr_model_code
+                "Cannot initialize %s: Tuya denied access to the local key. "
+                "Re-link the vacuum in the Eufy app or check account and "
+                "region permissions, then reload the integration.",
+                self._attr_name,
             )
-            self._attr_error_code = "UNSUPPORTED_MODEL"
+            self._attr_error_code = "LOCAL_KEY_UNAVAILABLE"
+        else:
+            try:
+                # Extract model code prefix for device identification
+                model_code_prefix = ""
+                if self.model_code is not None:
+                    model_code_prefix = self.model_code[0:5]
+
+                # Create the RoboVac instance
+                self.vacuum = RoboVac(
+                    device_id=self.unique_id,
+                    host=self.ip_address,
+                    local_key=self.access_token,
+                    timeout=TIMEOUT,
+                    ping_interval=PING_RATE,
+                    model_code=model_code_prefix,
+                    update_entity_state=self.pushed_update_handler,
+                )
+                _LOGGER.debug(
+                    "Initialized RoboVac connection for %s (model: %s)",
+                    self._attr_name,
+                    self._attr_model_code
+                )
+            except ModelNotSupportedException:
+                _LOGGER.error(
+                    "Model %s is not supported",
+                    self._attr_model_code
+                )
+                self._attr_error_code = "UNSUPPORTED_MODEL"
+            except InvalidKey:
+                _LOGGER.error(
+                    "Cannot initialize %s: Tuya returned an invalid local key. "
+                    "Re-link the vacuum in the Eufy app or check account and "
+                    "region permissions, then reload the integration.",
+                    self._attr_name,
+                )
+                self._attr_error_code = "INVALID_LOCAL_KEY"
 
         # Set supported features if vacuum was initialized successfully
         if self.vacuum is not None:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -29,6 +29,7 @@ from custom_components.robovac.config_flow import (
 )
 from custom_components.robovac.const import DOMAIN, CONF_AUTODISCOVERY, CONF_VACS
 from custom_components.robovac.robovac import RoboVac
+from custom_components.robovac.tuyawebapi import TuyaAPIError
 
 
 @pytest.fixture
@@ -264,10 +265,14 @@ async def test_user_form_keeps_eufy_device_when_tuya_denies_permission(
             "custom_components.robovac.config_flow.TuyaAPISession",
             return_value=MagicMock(
                 get_device=MagicMock(
-                    side_effect=KeyError(
-                        "No 'result' key in the response - the entire response is "
-                        "{'success': False, 'errorCode': 'PERMISSION_DENIED', "
-                        "'status': 'error', 'errorMsg': 'No access'}"
+                    side_effect=TuyaAPIError(
+                        "No access",
+                        {
+                            "success": False,
+                            "errorCode": "PERMISSION_DENIED",
+                            "status": "error",
+                            "errorMsg": "No access",
+                        },
                     )
                 )
             ),

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -233,6 +233,69 @@ async def test_user_form_success(
 
 
 @pytest.mark.asyncio
+async def test_user_form_keeps_eufy_device_when_tuya_denies_permission(
+    hass: HomeAssistant, mock_eufy_response
+) -> None:
+    """Test Eufy-discovered vacuums are retained when Tuya denies device access."""
+    mock_eufy_response["device_info"].json.return_value["devices"][0]["product"][
+        "product_code"
+    ] = "T2292"
+    mock_eufy_response["device_info"].json.return_value["devices"][0][
+        "alias_name"
+    ] = "Bob Junior"
+    mock_eufy_response["device_info"].json.return_value["devices"][0][
+        "name"
+    ] = "AE C10"
+
+    with (
+        patch(
+            "custom_components.robovac.config_flow.EufyLogon",
+            return_value=MagicMock(
+                get_user_info=MagicMock(return_value=mock_eufy_response["user_info"]),
+                get_device_info=MagicMock(
+                    return_value=mock_eufy_response["device_info"]
+                ),
+                get_user_settings=MagicMock(
+                    return_value=mock_eufy_response["settings"]
+                ),
+            ),
+        ),
+        patch(
+            "custom_components.robovac.config_flow.TuyaAPISession",
+            return_value=MagicMock(
+                get_device=MagicMock(
+                    side_effect=KeyError(
+                        "No 'result' key in the response - the entire response is "
+                        "{'success': False, 'errorCode': 'PERMISSION_DENIED', "
+                        "'status': 'error', 'errorMsg': 'No access'}"
+                    )
+                )
+            ),
+        ),
+        patch(
+            "custom_components.robovac.TuyaLocalDiscovery",
+            return_value=MagicMock(start=AsyncMock(), close=MagicMock()),
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data={
+                CONF_USERNAME: "test-username",
+                CONF_PASSWORD: "test-password",
+            },
+        )
+
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert "test_device_id" in result["data"][CONF_VACS]
+    vacuum = result["data"][CONF_VACS]["test_device_id"]
+    assert vacuum[CONF_MODEL] == "T2292"
+    assert vacuum[CONF_NAME] == "Bob Junior"
+    assert vacuum[CONF_DESCRIPTION] == "AE C10"
+    assert vacuum[CONF_ACCESS_TOKEN] == ""
+
+
+@pytest.mark.asyncio
 async def test_user_form_no_vacuums_found(
     hass: HomeAssistant, mock_eufy_response
 ) -> None:

--- a/tests/test_tuyawebapi.py
+++ b/tests/test_tuyawebapi.py
@@ -93,6 +93,7 @@ def test_tuya_api_session_request_raises_structured_permission_error(mock_post) 
         session._request("tuya.m.device.get", version="1.0", data={"devId": "device"})
 
     assert exc_info.value.error_code == "PERMISSION_DENIED"
+    assert str(exc_info.value) == "PERMISSION_DENIED: No access"
 
 
 def test_tuya_api_session_determine_password() -> None:

--- a/tests/test_tuyawebapi.py
+++ b/tests/test_tuyawebapi.py
@@ -1,6 +1,6 @@
 import pytest
 from unittest.mock import patch, MagicMock
-from custom_components.robovac.tuyawebapi import TuyaAPISession
+from custom_components.robovac.tuyawebapi import TuyaAPIError, TuyaAPISession
 
 
 def test_generate_new_device_id() -> None:
@@ -71,6 +71,28 @@ def test_tuya_api_session_request(mock_post) -> None:
     # Check that query string gets sign
     args, kwargs = mock_post.call_args
     assert "sign" in kwargs["params"]
+
+
+@patch("custom_components.robovac.tuyawebapi.requests.Session.post")
+def test_tuya_api_session_request_raises_structured_permission_error(mock_post) -> None:
+    """Test Tuya permission errors retain the API error code."""
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "success": False,
+        "errorCode": "PERMISSION_DENIED",
+        "status": "error",
+        "errorMsg": "No access",
+    }
+    mock_response.raise_for_status.return_value = None
+    mock_post.return_value = mock_response
+
+    session = TuyaAPISession("username", "EU", "Europe/London", "44")
+    session.session_id = "test_sid"
+
+    with pytest.raises(TuyaAPIError) as exc_info:
+        session._request("tuya.m.device.get", version="1.0", data={"devId": "device"})
+
+    assert exc_info.value.error_code == "PERMISSION_DENIED"
 
 
 def test_tuya_api_session_determine_password() -> None:

--- a/tests/test_vacuum/test_vacuum_entity.py
+++ b/tests/test_vacuum/test_vacuum_entity.py
@@ -27,6 +27,28 @@ from custom_components.robovac.vacuum import (
 from custom_components.robovac.vacuums.base import TuyaCodes
 
 
+def test_entity_with_missing_local_key_reports_actionable_error(mock_vacuum_data) -> None:
+    """Test permission-denied discovery does not crash entity initialization."""
+    vacuum_data = {
+        **mock_vacuum_data,
+        CONF_MODEL: "T2292",
+        CONF_DESCRIPTION: "AE C10",
+        CONF_ACCESS_TOKEN: "",
+    }
+
+    entity = RoboVacEntity(vacuum_data)
+
+    assert entity.vacuum is None
+    assert entity.error_code == "LOCAL_KEY_UNAVAILABLE"
+    assert entity.activity == VacuumActivity.ERROR
+    assert (
+        entity.extra_state_attributes[ATTR_ERROR]
+        == "Tuya denied access to this vacuum's local key. Re-link the vacuum in "
+        "the Eufy app or check account and region permissions, then reload the "
+        "integration."
+    )
+
+
 @pytest.mark.asyncio
 async def test_activity_property_none(mock_robovac, mock_vacuum_data) -> None:
     """Test activity property returns None when tuya_state is None."""


### PR DESCRIPTION
## Summary
- classify Tuya API error payloads with structured error codes
- keep Eufy-discovered vacuums when Tuya returns PERMISSION_DENIED, using an empty local key instead of dropping the device
- add regression coverage for the C10/T2292 permission-denied discovery path

## Tests
- ./.venv/bin/pytest tests/test_tuyawebapi.py tests/test_config_flow.py
- ./.venv/bin/flake8 custom_components/robovac/config_flow.py custom_components/robovac/tuyawebapi.py tests/test_config_flow.py tests/test_tuyawebapi.py

Fixes #487
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/robovac/pull/536" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->