### PR TITLE
Fix: stop vacuum without returning to base

### DIFF
--- a/custom_components/robovac/vacuum.py
+++ b/custom_components/robovac/vacuum.py
@@ -1572,7 +1572,7 @@ class RoboVacEntity(StateVacuumEntity):
         Args:
             **kwargs: Additional arguments passed from Home Assistant.
         """
-        await self.async_return_to_base()
+        await self.async_pause(**kwargs)
 
     async def async_clean_spot(self, **kwargs: Any) -> None:
         """Perform a spot clean.

--- a/tests/test_vacuum/test_vacuum_commands.py
+++ b/tests/test_vacuum/test_vacuum_commands.py
@@ -372,13 +372,13 @@ async def test_async_stop(mock_robovac, mock_vacuum_data) -> None:
     with patch("custom_components.robovac.vacuum.RoboVac", return_value=mock_robovac):
         entity = RoboVacEntity(mock_vacuum_data)
 
-        # Mock the async_return_to_base method
-        with patch.object(entity, "async_return_to_base") as mock_return:
+        # Mock the async_pause method
+        with patch.object(entity, "async_pause") as mock_pause:
             # Act
             await entity.async_stop()
 
             # Assert
-            mock_return.assert_called_once()
+            mock_pause.assert_awaited_once_with()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes the Home Assistant Stop action so it stops the vacuum in place instead of triggering a return to dock.

`async_stop()` currently calls `async_return_to_base()`. This changes it to call `async_pause(**kwargs)` instead.
