### PR TITLE
fix: defined consumables for T2267

### DIFF
--- a/custom_components/robovac/vacuums/T2267.py
+++ b/custom_components/robovac/vacuums/T2267.py
@@ -1,4 +1,5 @@
 """RoboVac L60 (T2267)"""
+
 from homeassistant.components.vacuum import VacuumEntityFeature
 from .base import RoboVacEntityFeature, RobovacCommand, RobovacModelDetails
 
@@ -15,9 +16,15 @@ class T2267(RobovacModelDetails):
         | VacuumEntityFeature.STOP
     )
     robovac_features = (
-        RoboVacEntityFeature.DO_NOT_DISTURB
-        | RoboVacEntityFeature.BOOST_IQ
+        RoboVacEntityFeature.DO_NOT_DISTURB | RoboVacEntityFeature.BOOST_IQ
     )
+    consumable_sensor_keys = [
+        "side_brush",
+        "rolling_brush",
+        "filter_mesh",
+        "sensor",
+        "dustbag",
+    ]
     commands = {
         RobovacCommand.MODE: {
             "code": 152,
@@ -92,5 +99,5 @@ class T2267(RobovacModelDetails):
         },
         RobovacCommand.ERROR: {
             "code": 177,
-        }
+        },
     }


### PR DESCRIPTION
Defines available consumables and removes MOP and SCRAPER sensors, since they are not available on this model and can now be deleted from HA.