### PR TITLE
feat(T2256): add RoboVac G40 Hybrid support

### DIFF
--- a/custom_components/robovac/vacuums/T2256.py
+++ b/custom_components/robovac/vacuums/T2256.py
@@ -1,0 +1,80 @@
+"""RoboVac G40 Hybrid (T2256).
+
+Added 2026-06-24: the plain G40 Hybrid (Tuya model code T2256) was missing from
+damacus/robovac — it had the base G40 (T2255), G40+ (T2272) and G40 Hybrid+ (T2273)
+but not this variant, so the device reported "model is not supported". Profile cloned
+from the G40 Hybrid+ (T2273): the G40 family shares the same Tuya DP codes
+(start/pause 2, status 15, return-home 101, fan 102, battery 104, error 106).
+"""
+from homeassistant.components.vacuum import VacuumEntityFeature
+from .base import RoboVacEntityFeature, RobovacCommand, RobovacModelDetails
+
+
+class T2256(RobovacModelDetails):
+    homeassistant_features = (
+        VacuumEntityFeature.CLEAN_SPOT
+        | VacuumEntityFeature.FAN_SPEED
+        | VacuumEntityFeature.LOCATE
+        | VacuumEntityFeature.PAUSE
+        | VacuumEntityFeature.RETURN_HOME
+        | VacuumEntityFeature.SEND_COMMAND
+        | VacuumEntityFeature.START
+        | VacuumEntityFeature.STATE
+        | VacuumEntityFeature.STOP
+    )
+    robovac_features = (
+        RoboVacEntityFeature.CLEANING_TIME
+        | RoboVacEntityFeature.CLEANING_AREA
+        | RoboVacEntityFeature.DO_NOT_DISTURB
+        | RoboVacEntityFeature.AUTO_RETURN
+        | RoboVacEntityFeature.CONSUMABLES
+    )
+    commands = {
+        RobovacCommand.START_PAUSE: {
+            "code": 2,
+            "values": {"start": True, "pause": False},
+        },
+        RobovacCommand.DIRECTION: {
+            "code": 3,
+            "values": {
+                "forward": "forward",
+                "back": "back",
+                "left": "left",
+                "right": "right",
+            },
+        },
+        RobovacCommand.MODE: {
+            "code": 5,
+            "values": {
+                "auto": "Auto",
+                "small_room": "SmallRoom",
+                "spot": "Spot",
+                "edge": "Edge",
+                "nosweep": "Nosweep",
+            },
+        },
+        RobovacCommand.STATUS: {
+            "code": 15,
+        },
+        RobovacCommand.RETURN_HOME: {
+            "code": 101,
+        },
+        RobovacCommand.FAN_SPEED: {
+            "code": 102,
+            "values": {
+                "quiet": "Quiet",
+                "standard": "Standard",
+                "turbo": "Turbo",
+                "max": "Max",
+            },
+        },
+        RobovacCommand.LOCATE: {
+            "code": 103,
+        },
+        RobovacCommand.BATTERY: {
+            "code": 104,
+        },
+        RobovacCommand.ERROR: {
+            "code": 106,
+        },
+    }

--- a/custom_components/robovac/vacuums/__init__.py
+++ b/custom_components/robovac/vacuums/__init__.py
@@ -25,6 +25,7 @@ from .T2252 import T2252
 from .T2253 import T2253
 from .T2254 import T2254
 from .T2255 import T2255
+from .T2256 import T2256
 from .T2258 import T2258
 from .T2259 import T2259
 from .T2261 import T2261
@@ -64,6 +65,7 @@ ROBOVAC_MODELS: Dict[str, Type[RobovacModelDetails]] = {
     "T2210": T2210,
     "T2212": T2212,
     "T2255": T2255,
+    "T2256": T2256,
     "T2258": T2258,
     "T2259": T2259,
     "T2270": T2270,

--- a/site_docs/supported-models.md
+++ b/site_docs/supported-models.md
@@ -31,6 +31,7 @@ This page lists all currently supported Eufy RoboVac models.
 | T2253      | RoboVac G30 Hybrid          | 3.3      |
 | T2254      | eufy Clean G35              | 3.3      |
 | T2255      | eufy Clean G40              | 3.3      |
+| T2256      | RoboVac G40 Hybrid          | 3.3      |
 | T2258      | RoboVac G20 Hybrid          | 3.3      |
 | T2259      | RoboVac G32 Pro             | 3.3      |
 | T2261      | RoboVac X8 Hybrid           | 3.3      |


### PR DESCRIPTION
Adds the **RoboVac G40 Hybrid** (Tuya model code **T2256**) — it was missing: the repo had the base G40 (T2255), G40+ (T2272), and G40 Hybrid+ (T2273) but not the plain G40 Hybrid, so those devices reported `model is not supported`. Profile cloned from the G40 Hybrid+ (T2273); the G40 family shares the same Tuya DP codes (start/pause 2, status 15, return-home 101, fan 102, battery 104, error 106).

**Verified on a real G40 Hybrid:** model code confirmed T2256 via the eufy device map; after registering, the device reports `docked` / battery 74% / fan-speed Standard / full controls (supported_features 14140) instead of the error. Also added the row to supported-models.md.