### PR TITLE
⚡ Bolt: Memoize clean param parsing to prevent redundant decodes

### DIFF
--- a/custom_components/robovac/vacuum.py
+++ b/custom_components/robovac/vacuum.py
@@ -21,7 +21,6 @@ import asyncio
 import base64
 from dataclasses import dataclass
 from datetime import timedelta
-from enum import StrEnum
 import json
 import logging
 import time
@@ -726,6 +725,7 @@ class RoboVacEntity(StateVacuumEntity):
         self._consumables_codes_cache: list[str] | None = None
         self._dps_codes_memo: dict[str, str] = {}
         self._last_consumable_data: str | None = None
+        self._last_clean_param_data: str | None = None
         self._room_name_registry: dict[str, dict[str, Any]] = {}
         self._eufy_username: str | None = item.get(CONF_USERNAME)
         self._eufy_password: str | None = item.get(CONF_PASSWORD)
@@ -1073,6 +1073,11 @@ class RoboVacEntity(StateVacuumEntity):
 
         try:
             raw_str = raw if isinstance(raw, str) else str(raw)
+            # ⚡ Bolt optimization: Avoid redundant decodes by memoizing the payload
+            if raw_str == self._last_clean_param_data:
+                return
+            self._last_clean_param_data = raw_str
+
             decoded = decode_clean_param_response(raw_str)
             params = merge_clean_param_layers(decoded)
             clean_type = params.get("clean_type")


### PR DESCRIPTION
* 💡 What: The optimization implemented caching for the raw "CLEAN_PARAM" DPS payload to skip redundant base64 decodes and object creations in `_update_clean_param_attributes` when the string hasn't changed.
* 🎯 Why: Vacuum entities receive frequent push updates over the Tuya protocol where many data points (like static clean parameters) don't change. Attempting to parse, decode, and merge these layers on every single event causes unnecessary overhead. 
* 📊 Impact: Significantly reduces CPU cycles and memory allocations inside `_update_clean_param_attributes` on the hot path (update cycle), mirroring a similar successful optimization made previously for consumables.
* 🔬 Measurement: Observe CPU load and profiling logs during regular polling/Tuya status push cycles on an instance with `CLEAN_PARAM` supporting vacuums. The decoding code path will only be triggered when parameters actually change.

---
*PR created automatically by Jules for task [541717787007996168](https://jules.google.com/task/541717787007996168) started by @damacus*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/robovac/pull/549" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->