### PR TITLE
feat: add T211A Omni C28 support

### DIFF
--- a/custom_components/robovac/config_flow.py
+++ b/custom_components/robovac/config_flow.py
@@ -82,16 +82,36 @@ def _vacuum_details_from_eufy_item(
     item: dict[str, Any], access_token: str
 ) -> dict[str, Any]:
     """Build config-flow vacuum details from an Eufy device record."""
+    wifi = item.get("wifi") or {}
     return {
         CONF_ID: item["id"],
         CONF_MODEL: item["product"]["product_code"],
-        CONF_NAME: item["alias_name"],
+        CONF_NAME: item.get("alias_name") or item["name"],
         CONF_DESCRIPTION: item["name"],
-        CONF_MAC: item["wifi"]["mac"],
+        CONF_MAC: wifi.get("mac", ""),
         CONF_IP_ADDRESS: "",
         CONF_AUTODISCOVERY: True,
         CONF_ACCESS_TOKEN: access_token,
     }
+
+
+def _eufy_device_records(device_response: dict[str, Any]) -> list[dict[str, Any]]:
+    """Normalize Eufy device responses into device records."""
+    records: list[dict[str, Any]] = []
+
+    devices = device_response.get("devices")
+    if isinstance(devices, list):
+        records.extend(device for device in devices if isinstance(device, dict))
+
+    items = device_response.get("items")
+    if isinstance(items, list):
+        records.extend(
+            item["device"]
+            for item in items
+            if isinstance(item, dict) and isinstance(item.get("device"), dict)
+        )
+
+    return records
 
 
 def get_eufy_vacuums(self: dict[str, Any]) -> requests.Response:
@@ -179,10 +199,11 @@ def get_eufy_vacuums(self: dict[str, Any]) -> requests.Response:
         phone_code=self[CONF_COUNTRY_CODE],
     )
 
-    items = device_response["devices"]
+    items = _eufy_device_records(device_response)
     self[CONF_VACS] = {}
     for item in items:
-        if item["product"]["appliance"] == "Cleaning":
+        product = item.get("product") or {}
+        if product.get("appliance") == "Cleaning":
             try:
                 device = tuya_client.get_device(item["id"])
                 access_token = device["localKey"]

--- a/custom_components/robovac/eufywebapi.py
+++ b/custom_components/robovac/eufywebapi.py
@@ -93,11 +93,41 @@ class EufyLogon:
             Response object or None if connection error occurs.
         """
         device_url = url + "/v1/device/v2"
+        devices_and_groups_url = (
+            "https://home-api.eufylife.com/v1/device/list/devices-and-groups"
+        )
         # Create a local copy of headers to prevent cross-session data leakage
         headers = eufyheaders.copy()
         headers["token"] = token
         headers["id"] = userid
         try:
-            return requests.request("GET", device_url, headers=headers, timeout=10)
+            response = requests.request("GET", device_url, headers=headers, timeout=10)
+            if self._has_device_records(response):
+                return response
+
+            return requests.request(
+                "GET", devices_and_groups_url, headers=headers, timeout=10
+            )
         except requests.exceptions.RequestException:
             return None
+
+    @staticmethod
+    def _has_device_records(response: requests.Response) -> bool:
+        """Return True when a Eufy device response contains device records."""
+        try:
+            payload = response.json()
+        except ValueError:
+            return False
+
+        devices = payload.get("devices")
+        if isinstance(devices, list) and devices:
+            return True
+
+        items = payload.get("items")
+        if not isinstance(items, list):
+            return False
+
+        return any(
+            isinstance(item, dict) and isinstance(item.get("device"), dict)
+            for item in items
+        )

--- a/custom_components/robovac/model_validator.py
+++ b/custom_components/robovac/model_validator.py
@@ -13,7 +13,7 @@ from .vacuums import ROBOVAC_MODELS
 
 # Series detection patterns
 SERIES_PATTERNS = {
-    "C": r"^T2(103|123)$",
+    "C": r"^T2(103|11A|123)$",
     "G": r"^T2(150|210|212|261)$",
     "L": r"^T2(2[67][0-9]|278|320)$",
     "X": r"^T2(080|117|118|119|120|128|130|132|181|190|192|193|194|25[0-9]|262)$",
@@ -132,11 +132,18 @@ def suggest_similar_models(
         try:
             model_num = int(model_code[1:])
             # Find models with closest numeric values
+            numeric_supported = []
+            for model in supported:
+                try:
+                    numeric_supported.append((model, int(model[1:])))
+                except (ValueError, IndexError):
+                    continue
+
             similar = sorted(
-                supported,
-                key=lambda m: abs(int(m[1:]) - model_num),
+                numeric_supported,
+                key=lambda item: abs(item[1] - model_num),
             )
-            for model in similar:
+            for model, _model_num in similar:
                 if model not in [s[0] for s in suggestions]:
                     suggestions.append((model, "Similar model number"))
                     if len(suggestions) >= max_suggestions:

--- a/custom_components/robovac/vacuums/T211A.py
+++ b/custom_components/robovac/vacuums/T211A.py
@@ -1,9 +1,9 @@
 """eufy Omni C28 (T211A)."""
 
-from .T2280 import T2280
+from .T2320 import T2320
 
 
-class T211A(T2280):
-    """Omni C28 shares the Omni C-series command profile."""
+class T211A(T2320):
+    """Omni C28 uses the station-aware RoboVac and mop command profile."""
 
     pass

--- a/custom_components/robovac/vacuums/T211A.py
+++ b/custom_components/robovac/vacuums/T211A.py
@@ -1,0 +1,9 @@
+"""eufy Omni C28 (T211A)."""
+
+from .T2280 import T2280
+
+
+class T211A(T2280):
+    """Omni C28 shares the Omni C-series command profile."""
+
+    pass

--- a/custom_components/robovac/vacuums/__init__.py
+++ b/custom_components/robovac/vacuums/__init__.py
@@ -3,6 +3,7 @@ from typing import Dict, Type
 from .T1250 import T1250
 from .T2080 import T2080
 from .T2103 import T2103
+from .T211A import T211A
 from .T2117 import T2117
 from .T2118 import T2118
 from .T2119 import T2119
@@ -48,6 +49,7 @@ ROBOVAC_MODELS: Dict[str, Type[RobovacModelDetails]] = {
     "T1250": T1250,
     "T2080": T2080,
     "T2103": T2103,
+    "T211A": T211A,
     "T2117": T2117,
     "T2118": T2118,
     "T2119": T2119,

--- a/site_docs/supported-models.md
+++ b/site_docs/supported-models.md
@@ -9,6 +9,7 @@ This page lists all currently supported Eufy RoboVac models.
 | T1250      | RoboVac G40                 | 3.3      |
 | T2080      | RoboVac S1 Pro              | 3.4      |
 | T2103      | RoboVac 11S                 | 3.3      |
+| T211A      | eufy Omni C28               | 3.4      |
 | T2117      | RoboVac 35C                 | 3.3      |
 | T2118      | RoboVac 30C                 | 3.3      |
 | T2119      | RoboVac 11S Plus            | 3.3      |
@@ -83,6 +84,7 @@ series, it may work with an existing configuration.
 ### Omni Series
 
 - **C20**: T2280
+- **C28**: T211A
 
 ### Classic Series
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -234,6 +234,71 @@ async def test_user_form_success(
 
 
 @pytest.mark.asyncio
+async def test_user_form_success_with_devices_and_groups_response(
+    hass: HomeAssistant, mock_eufy_response, mock_tuya_device
+) -> None:
+    """Test setup handles the Eufy devices-and-groups endpoint response."""
+    mock_eufy_response["device_info"].json.return_value = {
+        "items": [
+            {
+                "item_type": 0,
+                "device": {
+                    "id": "test_c28_device_id",
+                    "name": "Omni C28",
+                    "alias_name": "Robovac",
+                    "product": {
+                        "appliance": "Cleaning",
+                        "product_code": "T211A",
+                    },
+                    "wifi": {"mac": "AA:BB:CC:DD:EE:FF"},
+                },
+                "group": None,
+            }
+        ]
+    }
+
+    with (
+        patch(
+            "custom_components.robovac.config_flow.EufyLogon",
+            return_value=MagicMock(
+                get_user_info=MagicMock(return_value=mock_eufy_response["user_info"]),
+                get_device_info=MagicMock(
+                    return_value=mock_eufy_response["device_info"]
+                ),
+                get_user_settings=MagicMock(
+                    return_value=mock_eufy_response["settings"]
+                ),
+            ),
+        ),
+        patch(
+            "custom_components.robovac.config_flow.TuyaAPISession",
+            return_value=MagicMock(get_device=MagicMock(return_value=mock_tuya_device)),
+        ),
+        patch(
+            "custom_components.robovac.TuyaLocalDiscovery",
+            return_value=MagicMock(start=AsyncMock(), close=MagicMock()),
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data={
+                CONF_USERNAME: "test-username",
+                CONF_PASSWORD: "test-password",
+            },
+        )
+
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    vacuum = result["data"][CONF_VACS]["test_c28_device_id"]
+    assert vacuum[CONF_ID] == "test_c28_device_id"
+    assert vacuum[CONF_MODEL] == "T211A"
+    assert vacuum[CONF_NAME] == "Robovac"
+    assert vacuum[CONF_DESCRIPTION] == "Omni C28"
+    assert vacuum[CONF_MAC] == "AA:BB:CC:DD:EE:FF"
+    assert vacuum[CONF_ACCESS_TOKEN] == "test_local_key"
+
+
+@pytest.mark.asyncio
 async def test_user_form_keeps_eufy_device_when_tuya_denies_permission(
     hass: HomeAssistant, mock_eufy_response
 ) -> None:

--- a/tests/test_eufywebapi.py
+++ b/tests/test_eufywebapi.py
@@ -154,6 +154,65 @@ def test_get_device_info(mock_requests_request, mock_device_info_response) -> No
     assert "User-Agent" in kwargs["headers"]
 
 
+def test_get_device_info_falls_back_to_devices_and_groups(
+    mock_requests_request,
+) -> None:
+    """Test get_device_info falls back when the legacy endpoint has no devices."""
+    empty_legacy_response = MagicMock()
+    empty_legacy_response.json.return_value = {
+        "res_code": 1,
+        "message": "",
+        "devices": [],
+    }
+    devices_and_groups_response = MagicMock()
+    devices_and_groups_response.json.return_value = {
+        "res_code": 1,
+        "message": "",
+        "items": [
+            {
+                "item_type": 0,
+                "device": {
+                    "id": "test_device_id",
+                    "name": "Omni C28",
+                    "alias_name": "Robovac",
+                    "product": {
+                        "product_code": "T211A",
+                        "appliance": "Cleaning",
+                    },
+                    "wifi": {
+                        "mac": "AA:BB:CC:DD:EE:FF",
+                    },
+                },
+                "group": None,
+            }
+        ],
+    }
+    mock_requests_request.side_effect = [
+        empty_legacy_response,
+        devices_and_groups_response,
+    ]
+
+    eufy = EufyLogon("test@example.com", "password123")
+    response = eufy.get_device_info(
+        "https://appliances-api-eu.eufylife.com",
+        "test_user_id",
+        "test_access_token",
+    )
+
+    assert response == devices_and_groups_response
+    assert mock_requests_request.call_count == 2
+    assert mock_requests_request.call_args_list[0].args[1] == (
+        "https://appliances-api-eu.eufylife.com/v1/device/v2"
+    )
+    assert mock_requests_request.call_args_list[1].args[1] == (
+        "https://home-api.eufylife.com/v1/device/list/devices-and-groups"
+    )
+    assert (
+        mock_requests_request.call_args_list[1].kwargs["headers"]["token"]
+        == "test_access_token"
+    )
+
+
 def test_get_user_settings(mock_requests_request, mock_user_settings_response) -> None:
     """Test get_user_settings method."""
     # Set up the mock

--- a/tests/test_model_validator.py
+++ b/tests/test_model_validator.py
@@ -16,8 +16,9 @@ class TestSeriesDetection:
 
     def test_detect_c_series(self) -> None:
         """Test detection of C series models."""
-        # C series models: T2103, T2123
+        # C series models: T2103, T211A, T2123
         assert detect_series("T2103") == "C"
+        assert detect_series("T211A") == "C"
         assert detect_series("T2123") == "C"
 
     def test_detect_g_series(self) -> None:
@@ -58,6 +59,7 @@ class TestModelValidation:
         assert is_supported_model("T2278") is True
         assert is_supported_model("T2250") is True
         assert is_supported_model("T2080") is True
+        assert is_supported_model("T211A") is True
 
     def test_is_supported_model_false(self) -> None:
         """Test is_supported_model returns False for unknown models."""
@@ -81,6 +83,7 @@ class TestModelValidation:
         assert "T2278" in models
         assert "T2250" in models
         assert "T2080" in models
+        assert "T211A" in models
 
     def test_get_supported_models_no_duplicates(self) -> None:
         """Test get_supported_models has no duplicates."""

--- a/tests/test_vacuum/test_config_entities.py
+++ b/tests/test_vacuum/test_config_entities.py
@@ -52,6 +52,25 @@ async def test_t2320_exposes_config_entities() -> None:
 
 
 @pytest.mark.asyncio
+async def test_t211a_exposes_omni_config_entities() -> None:
+    """T211A exposes clean-param, fan, room, and mop configuration controls."""
+    entry = SimpleNamespace(data={CONF_VACS: {"vacuum": _vacuum_config("T211A")}})
+    select_entities = []
+    switch_entities = []
+
+    await async_setup_select_entry(None, entry, select_entities.extend)
+    await async_setup_switch_entry(None, entry, switch_entities.extend)
+
+    assert [entity.name for entity in select_entities] == [
+        "Fan speed",
+        "Clean type",
+        "Mop level",
+        "Room",
+    ]
+    assert [entity.name for entity in switch_entities] == ["Edge mopping"]
+
+
+@pytest.mark.asyncio
 async def test_other_clean_param_models_do_not_get_t2320_config_entities() -> None:
     """Avoid exposing X9-specific config controls on other clean-param models."""
     entry = SimpleNamespace(data={CONF_VACS: {"vacuum": _vacuum_config("T2277")}})
@@ -69,6 +88,27 @@ async def test_other_clean_param_models_do_not_get_t2320_config_entities() -> No
 async def test_t2320_does_not_duplicate_clean_type_as_diagnostic_sensor() -> None:
     """T2320 exposes clean type as configuration, not a duplicate sensor."""
     entry = SimpleNamespace(data={CONF_VACS: {"vacuum": _vacuum_config("T2320")}})
+    sensor_entities = []
+
+    await async_setup_sensor_entry(None, entry, sensor_entities.extend)
+
+    sensor_names = [entity.name for entity in sensor_entities]
+    assert "Clean Type" not in sensor_names
+    assert "Notification" in sensor_names
+    assert "Warning" in sensor_names
+    assert "Side Brush" in sensor_names
+    assert "Rolling Brush" in sensor_names
+    assert "Filter" in sensor_names
+    assert "Scraper" in sensor_names
+    assert "Sensor" in sensor_names
+    assert "Mop" in sensor_names
+    assert "Dust Bag" not in sensor_names
+
+
+@pytest.mark.asyncio
+async def test_t211a_exposes_omni_diagnostic_sensors() -> None:
+    """T211A exposes station warnings and consumables without duplicate clean type."""
+    entry = SimpleNamespace(data={CONF_VACS: {"vacuum": _vacuum_config("T211A")}})
     sensor_entities = []
 
     await async_setup_sensor_entry(None, entry, sensor_entities.extend)

--- a/tests/test_vacuum/test_t211a_command_mappings.py
+++ b/tests/test_vacuum/test_t211a_command_mappings.py
@@ -1,0 +1,53 @@
+"""Tests for T211A (Omni C28) command mappings and registration."""
+
+from unittest.mock import patch
+
+import pytest
+
+from custom_components.robovac.robovac import RoboVac
+from custom_components.robovac.vacuums import ROBOVAC_MODELS
+from custom_components.robovac.vacuums.T2280 import T2280
+from custom_components.robovac.vacuums.base import RobovacCommand
+
+
+def test_t211a_registered_in_robovac_models() -> None:
+    """Test T211A is registered in ROBOVAC_MODELS."""
+    assert ROBOVAC_MODELS["T211A"].commands == T2280.commands
+
+
+@pytest.fixture
+def mock_t211a_robovac() -> RoboVac:
+    """Create a mock T211A RoboVac instance for testing."""
+    with patch("custom_components.robovac.robovac.TuyaDevice.__init__", return_value=None):
+        robovac = RoboVac(
+            model_code="T211A",
+            device_id="test_id",
+            host="192.168.1.100",
+            local_key="test_key",
+        )
+        return robovac
+
+
+def test_t211a_mode_command_values(mock_t211a_robovac: RoboVac) -> None:
+    """Test T211A MODE command uses the Omni C-series values."""
+    assert (
+        mock_t211a_robovac.getRoboVacCommandValue(RobovacCommand.MODE, "auto")
+        == "BBoCCAE="
+    )
+    assert (
+        mock_t211a_robovac.getRoboVacCommandValue(RobovacCommand.MODE, "pause")
+        == "AggN"
+    )
+
+
+def test_t211a_model_has_commands(mock_t211a_robovac: RoboVac) -> None:
+    """Test that T211A model has required commands defined."""
+    commands = mock_t211a_robovac.model_details.commands
+
+    assert RobovacCommand.MODE in commands
+    assert RobovacCommand.STATUS in commands
+    assert RobovacCommand.RETURN_HOME in commands
+    assert RobovacCommand.FAN_SPEED in commands
+    assert RobovacCommand.LOCATE in commands
+    assert RobovacCommand.BATTERY in commands
+    assert RobovacCommand.ERROR in commands

--- a/tests/test_vacuum/test_t211a_command_mappings.py
+++ b/tests/test_vacuum/test_t211a_command_mappings.py
@@ -3,16 +3,17 @@
 from unittest.mock import patch
 
 import pytest
+from homeassistant.components.vacuum import VacuumEntityFeature
 
 from custom_components.robovac.robovac import RoboVac
 from custom_components.robovac.vacuums import ROBOVAC_MODELS
-from custom_components.robovac.vacuums.T2280 import T2280
-from custom_components.robovac.vacuums.base import RobovacCommand
+from custom_components.robovac.vacuums.T2320 import T2320
+from custom_components.robovac.vacuums.base import RoboVacEntityFeature, RobovacCommand
 
 
 def test_t211a_registered_in_robovac_models() -> None:
     """Test T211A is registered in ROBOVAC_MODELS."""
-    assert ROBOVAC_MODELS["T211A"].commands == T2280.commands
+    assert ROBOVAC_MODELS["T211A"].commands == T2320.commands
 
 
 @pytest.fixture
@@ -28,8 +29,33 @@ def mock_t211a_robovac() -> RoboVac:
         return robovac
 
 
+def test_t211a_ha_features_match_station_omni_profile(
+    mock_t211a_robovac: RoboVac,
+) -> None:
+    """Test T211A exposes the HA controls used by station-capable models."""
+    assert mock_t211a_robovac.getHomeAssistantFeatures() == (
+        VacuumEntityFeature.FAN_SPEED
+        | VacuumEntityFeature.LOCATE
+        | VacuumEntityFeature.PAUSE
+        | VacuumEntityFeature.RETURN_HOME
+        | VacuumEntityFeature.SEND_COMMAND
+        | VacuumEntityFeature.START
+        | VacuumEntityFeature.STATE
+        | VacuumEntityFeature.STOP
+    )
+
+
+def test_t211a_robovac_features_match_station_omni_profile(
+    mock_t211a_robovac: RoboVac,
+) -> None:
+    """Test T211A exposes local feature flags implemented for Omni station models."""
+    assert mock_t211a_robovac.getRoboVacFeatures() == (
+        RoboVacEntityFeature.DO_NOT_DISTURB | RoboVacEntityFeature.BOOST_IQ
+    )
+
+
 def test_t211a_mode_command_values(mock_t211a_robovac: RoboVac) -> None:
-    """Test T211A MODE command uses the Omni C-series values."""
+    """Test T211A MODE command uses station-aware protobuf values."""
     assert (
         mock_t211a_robovac.getRoboVacCommandValue(RobovacCommand.MODE, "auto")
         == "BBoCCAE="
@@ -40,14 +66,59 @@ def test_t211a_mode_command_values(mock_t211a_robovac: RoboVac) -> None:
     )
 
 
-def test_t211a_model_has_commands(mock_t211a_robovac: RoboVac) -> None:
-    """Test that T211A model has required commands defined."""
+def test_t211a_model_has_omni_station_commands(mock_t211a_robovac: RoboVac) -> None:
+    """Test T211A has the local command surface for Omni station features."""
     commands = mock_t211a_robovac.model_details.commands
 
+    assert RobovacCommand.START_PAUSE in commands
     assert RobovacCommand.MODE in commands
     assert RobovacCommand.STATUS in commands
     assert RobovacCommand.RETURN_HOME in commands
+    assert RobovacCommand.CLEAN_PARAM in commands
     assert RobovacCommand.FAN_SPEED in commands
     assert RobovacCommand.LOCATE in commands
     assert RobovacCommand.BATTERY in commands
+    assert RobovacCommand.CONSUMABLES in commands
     assert RobovacCommand.ERROR in commands
+    assert RobovacCommand.ACTIVE_ERRORS in commands
+
+
+def test_t211a_dps_codes_match_local_station_profile(
+    mock_t211a_robovac: RoboVac,
+) -> None:
+    """Test T211A uses DPS codes for local station/mop feature support."""
+    dps_codes = mock_t211a_robovac.getDpsCodes()
+
+    assert dps_codes["START_PAUSE"] == "2"
+    assert dps_codes["MODE"] == "152"
+    assert dps_codes["STATUS"] == "173"
+    assert dps_codes["RETURN_HOME"] == "153"
+    assert dps_codes["CLEAN_PARAM"] == "154"
+    assert dps_codes["FAN_SPEED"] == "158"
+    assert dps_codes["LOCATE"] == "160"
+    assert dps_codes["BATTERY_LEVEL"] == "163"
+    assert dps_codes["CONSUMABLES"] == "168"
+    assert dps_codes["ERROR_CODE"] == "177"
+    assert dps_codes["ACTIVE_ERRORS"] == "178"
+    assert dps_codes["ROOM_META"] == "165"
+
+
+def test_t211a_exposes_config_entity_flags() -> None:
+    """Test T211A opts into local clean type, mop level, and room controls."""
+    model = ROBOVAC_MODELS["T211A"]
+
+    assert getattr(model, "expose_config_entities") is True
+    assert getattr(model, "clean_type_select_keys") == (
+        "sweep_only",
+        "mop_only",
+        "sweep_and_mop",
+    )
+    assert getattr(model, "expose_room_select") is True
+    assert getattr(model, "consumable_sensor_keys") == (
+        "side_brush",
+        "rolling_brush",
+        "filter_mesh",
+        "scrape",
+        "sensor",
+        "mop",
+    )


### PR DESCRIPTION
## Summary
- add T211A / eufy Omni C28 support
- use the existing station-aware RoboVac/mop command profile so T211A exposes readable suction levels, clean type, mop level, room select, station warnings, active notifications, and consumable sensors
- fall back from `/v1/device/v2` to `/v1/device/list/devices-and-groups` when the legacy Eufy endpoint returns no devices
- accept both the legacy `devices[]` payload and the newer `items[].device` payload when extracting Eufy device records
- document T211A in the supported models list

Fixes #357.

## Validation
- `.venv/bin/python -m pytest --cov=custom_components tests --cov-report=xml` (739 passed)
- `.venv/bin/flake8 custom_components tests`
- `.venv/bin/mypy --config-file=pyproject.toml custom_components`
- `.venv/bin/python -m pytest tests/test_vacuum/test_t211a_command_mappings.py tests/test_vacuum/test_config_entities.py -q`

## Notes
- `task`, `uv`, and `markdownlint-cli2` were not available globally in this shell, so validation used the same underlying tools from the repo-local `.venv`.
- No map/zone/cleaning-time feature flags were added beyond the local station-aware profile because those are not exposed by the shared profile used here.