### PR TITLE
fix(T2194): add missing values mapping for RETURN_HOME command

### DIFF
--- a/custom_components/robovac/vacuums/T2194.py
+++ b/custom_components/robovac/vacuums/T2194.py
@@ -65,6 +65,7 @@ class T2194(RobovacModelDetails):
         },
         RobovacCommand.RETURN_HOME: {
             "code": 101,
+	    "values": {"return": True},
         },
         RobovacCommand.FAN_SPEED: {
             "code": 130,

--- a/tests/test_vacuum/test_t2194_command_mappings.py
+++ b/tests/test_vacuum/test_t2194_command_mappings.py
@@ -85,3 +85,16 @@ def test_t2194_model_has_commands(mock_t2194_robovac) -> None:
     assert RobovacCommand.LOCATE in commands
     assert RobovacCommand.BATTERY in commands
     assert RobovacCommand.ERROR in commands
+
+
+def test_t2194_return_home_value(mock_t2194_robovac) -> None:
+    """Test T2194 RETURN_HOME maps 'return' to boolean True.
+
+    RETURN_HOME had no 'values' mapping, so getRoboVacCommandValue()
+    fell back to returning the raw string "return" instead of the
+    boolean the device expects on DPS code 101 (confirmed via debug
+    logs showing DPS 101 reported as a bool in every status update).
+    This caused the vacuum to start cleaning instead of returning to
+    dock when 'Return to Dock' was pressed in Home Assistant.
+    """
+    assert mock_t2194_robovac.getRoboVacCommandValue(RobovacCommand.RETURN_HOME, "return") is True


### PR DESCRIPTION
## Problem

L35 Hybrid (T2194) vacuums don't return to dock when `vacuum.return_to_base` is called in Home Assistant — instead they start cleaning.

## Root cause

`RETURN_HOME` command in `T2194.py` had no `values` mapping:

```python
RobovacCommand.RETURN_HOME: {
    "code": 101,
},
```

`getRoboVacCommandValue()` falls back to sending the raw string `"return"` when no mapping exists, but DPS code 101 on this device is a boolean field — confirmed via debug logs where every status update reports `'101': False`. Sending a string instead of `True` causes the vacuum firmware to ignore the command and it starts a cleaning cycle instead.

## Fix

Added the missing values mapping:

```python
RobovacCommand.RETURN_HOME: {
    "code": 101,
    "values": {"return": True},
},
```

## Testing

- Added `test_t2194_return_home_value` regression test — passes.
- Confirmed on real L35 Hybrid hardware: before the fix, pressing 'Return to Dock' sent `{"101": "return"}` and the vacuum started cleaning. After the fix, it correctly returns to dock.
- Full test suite for this model (7 tests) passes.