### PR TITLE
fix: route return-home mappings

### DIFF
--- a/custom_components/robovac/vacuums/T2275.py
+++ b/custom_components/robovac/vacuums/T2275.py
@@ -34,7 +34,7 @@ class T2275(RobovacModelDetails):
         RobovacCommand.RETURN_HOME: {
             "code": 153,
             "values": {
-                "return_home": "AggB",
+                "return": "AggB",
             },
         },
         RobovacCommand.CLEAN_PARAM: {

--- a/custom_components/robovac/vacuums/T2280.py
+++ b/custom_components/robovac/vacuums/T2280.py
@@ -32,12 +32,7 @@ class T2280(RobovacModelDetails):
         RobovacCommand.STATUS: {
             "code": 173,
         },
-        RobovacCommand.RETURN_HOME: {
-            "code": 153,
-            "values": {
-                "return_home": "AggB",
-            }
-        },
+        RobovacCommand.RETURN_HOME: {"code": 153},
         RobovacCommand.FAN_SPEED: {
             "code": 154,
             "values": {

--- a/custom_components/robovac/vacuums/T2320.py
+++ b/custom_components/robovac/vacuums/T2320.py
@@ -91,7 +91,6 @@ class T2320(RobovacModelDetails):
         RobovacCommand.RETURN_HOME: {
             "code": 153,
             "values": {
-                "return_home": True,
                 "return": True,
             },
         },

--- a/custom_components/robovac/vacuums/T2351.py
+++ b/custom_components/robovac/vacuums/T2351.py
@@ -36,7 +36,7 @@ class T2351(RobovacModelDetails):
         RobovacCommand.STATUS: {
             "code": 173,
         },
-        RobovacCommand.RETURN_HOME: {"code": 153, "values": {"return_home": True}},
+        RobovacCommand.RETURN_HOME: {"code": 153, "values": {"return": True}},
         RobovacCommand.FAN_SPEED: {
             "code": 154,
             "values": {

--- a/tests/test_vacuum/test_t2275_command_mappings.py
+++ b/tests/test_vacuum/test_t2275_command_mappings.py
@@ -47,18 +47,6 @@ def test_t2275_mode_command_values(mock_t2275_robovac) -> None:
     assert mock_t2275_robovac.getRoboVacCommandValue(RobovacCommand.MODE, "unknown") == "unknown"
 
 
-def test_t2275_return_home_command_values(mock_t2275_robovac) -> None:
-    """Test T2275 RETURN_HOME value mapping."""
-    assert (
-        mock_t2275_robovac.getRoboVacCommandValue(RobovacCommand.RETURN_HOME, "return_home")
-        == "AggB"
-    )
-    assert (
-        mock_t2275_robovac.getRoboVacCommandValue(RobovacCommand.RETURN_HOME, "unknown")
-        == "unknown"
-    )
-
-
 def test_t2275_fan_speed_command_values(mock_t2275_robovac) -> None:
     """Test T2275 FAN_SPEED maps HA selections to direct fan speed values."""
     assert mock_t2275_robovac.getRoboVacCommandValue(RobovacCommand.FAN_SPEED, "quiet") == "Quiet"

--- a/tests/test_vacuum/test_t2320_command_mappings.py
+++ b/tests/test_vacuum/test_t2320_command_mappings.py
@@ -24,12 +24,6 @@ def t2320_robovac() -> RoboVac:
 class TestT2320CommandMappings:
     """Test T2320 command mappings match debug log expectations."""
 
-    def test_return_home_command_value(self, t2320_robovac):
-        """Test RETURN_HOME command returns boolean true as seen in debug logs."""
-        # Debug log shows: "dps": {"153": true}
-        result = t2320_robovac.getRoboVacCommandValue(RobovacCommand.RETURN_HOME, "return_home")
-        assert result is True
-
     def test_start_pause_command_exists(self, t2320_robovac):
         """Test START_PAUSE command is defined for T2320."""
         # Debug log shows: "dps": {"2": false}

--- a/tests/test_vacuum/test_vacuum_commands.py
+++ b/tests/test_vacuum/test_vacuum_commands.py
@@ -70,6 +70,37 @@ async def test_async_return_to_base(mock_robovac, mock_vacuum_data) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("model_code", "expected_payload"),
+    [
+        ("T2275", {"153": "AggB"}),
+        ("T2351", {"153": True}),
+    ],
+)
+async def test_async_return_to_base_uses_model_specific_value(
+    mock_vacuum_data,
+    model_code,
+    expected_payload,
+) -> None:
+    """Test return-to-base sends each model's device-specific DPS value."""
+    with patch("custom_components.robovac.robovac.TuyaDevice.__init__", return_value=None):
+        robovac = RoboVac(
+            model_code=model_code,
+            device_id="test_id",
+            host="192.168.1.100",
+            local_key="test_key",
+        )
+    robovac.async_set = AsyncMock(return_value=True)
+
+    model_data = {**mock_vacuum_data, CONF_MODEL: model_code}
+    with patch("custom_components.robovac.vacuum.RoboVac", return_value=robovac):
+        entity = RoboVacEntity(model_data)
+        await entity.async_return_to_base()
+
+    robovac.async_set.assert_awaited_once_with(expected_payload)
+
+
+@pytest.mark.asyncio
 async def test_async_start(mock_robovac, mock_vacuum_data) -> None:
     """Test the async_start method."""
     # Arrange


### PR DESCRIPTION
## Summary

- align model-specific return-home value mappings with the return key used by async_return_to_base
- activate the T2275 AggB and T2351 boolean payloads, and remove T2320’s redundant unreachable alias
- remove T2280’s unverified dead AggB mapping without changing its existing raw return fallback
- replace false-path direct mapper tests with public return-to-base payload coverage

## Verification

- task lint
- task type-check
- task test — 746 passed
- git diff --cached --check

## Risks / follow-ups

T2280 continues to use its existing raw return fallback; this PR does not activate an unverified device payload.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/robovac/pull/578" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->