### PR TITLE
fix(T2266): enable protocol 3.5 network behaviors (validated on real …

### DIFF
--- a/custom_components/robovac/vacuums/T2266.py
+++ b/custom_components/robovac/vacuums/T2266.py
@@ -14,17 +14,11 @@ model, the snapshot shows it does have a station with dust collection (DPS 126,
 base64 JSON). Neither this config nor the T2276 config maps DPS 126, though —
 station / dust-collect control is not exposed as a Home Assistant command.
 
-Unlike the T2276, this config does not opt into the protocol 3.5 network
-behaviors (protocol_35_empty_dps_query, protocol_35_map_data_keepalive). Those
-were validated for the T2276 with local packet captures; a cloud DPS snapshot
-cannot show whether the T2266 needs an empty-DPS status query or a DPS 121
-map-data keepalive on ping. Enable them only with a T2266 packet capture
-proving the behavior.
-Both protocol 3.5 network behaviors (protocol_35_empty_dps_query,
-protocol_35_map_data_keepalive) are enabled: live testing on a T2266
-(2026-08, HA 2026.7.4) confirmed it behaves exactly like the T2276 —
-without them the session key negotiates but every DPS query returns
-empty and the device closes the connection ~30 s after connect.
+Both protocol 3.5 network behaviours (protocol_35_empty_dps_query and
+protocol_35_map_data_keepalive) are enabled. Live T2266 testing confirmed that
+the session key negotiates without them, but every DPS query returns empty and
+the device closes the connection about 30 seconds later. With both behaviours
+enabled, DPS queries and push updates work and the connection remains open.
 """
 from homeassistant.components.vacuum import VacuumEntityFeature
 from .base import RoboVacEntityFeature, RobovacCommand, RobovacModelDetails

--- a/custom_components/robovac/vacuums/T2266.py
+++ b/custom_components/robovac/vacuums/T2266.py
@@ -20,6 +20,11 @@ were validated for the T2276 with local packet captures; a cloud DPS snapshot
 cannot show whether the T2266 needs an empty-DPS status query or a DPS 121
 map-data keepalive on ping. Enable them only with a T2266 packet capture
 proving the behavior.
+Both protocol 3.5 network behaviors (protocol_35_empty_dps_query,
+protocol_35_map_data_keepalive) are enabled: live testing on a T2266
+(2026-08, HA 2026.7.4) confirmed it behaves exactly like the T2276 —
+without them the session key negotiates but every DPS query returns
+empty and the device closes the connection ~30 s after connect.
 """
 from homeassistant.components.vacuum import VacuumEntityFeature
 from .base import RoboVacEntityFeature, RobovacCommand, RobovacModelDetails
@@ -27,6 +32,8 @@ from .base import RoboVacEntityFeature, RobovacCommand, RobovacModelDetails
 
 class T2266(RobovacModelDetails):
     protocol_version = 3.5
+    protocol_35_empty_dps_query = True
+    protocol_35_map_data_keepalive = True
     homeassistant_features = (
         VacuumEntityFeature.FAN_SPEED
         | VacuumEntityFeature.LOCATE

--- a/tests/test_vacuum/test_t2266_command_mappings.py
+++ b/tests/test_vacuum/test_t2266_command_mappings.py
@@ -31,19 +31,18 @@ def test_t2266_protocol_version() -> None:
     assert T2266.protocol_version == 3.5
 
 
-def test_t2266_does_not_opt_into_protocol_35_network_behaviors() -> None:
-    """T2266 must not enable the T2276's protocol 3.5 network opt-ins.
+def test_t2266_enables_protocol_35_network_behaviors() -> None:
+    """T2266 must enable its validated protocol 3.5 network behaviours.
 
     protocol_35_empty_dps_query and protocol_35_map_data_keepalive change what
     the integration sends on the wire (empty-DPS status queries, SET_COMMAND_NEW
-    writes to DPS 121 on ping). They were validated for the T2276 with packet
-    captures; no equivalent T2266 capture exists, so they must stay off until
-    one does.
+    writes to DPS 121 on ping). Live T2266 testing confirmed that both are
+    required for DPS queries, push updates, and a stable connection.
     """
     from custom_components.robovac.vacuums.T2266 import T2266
 
-    assert getattr(T2266, "protocol_35_empty_dps_query", False) is False
-    assert getattr(T2266, "protocol_35_map_data_keepalive", False) is False
+    assert T2266.protocol_35_empty_dps_query is True
+    assert T2266.protocol_35_map_data_keepalive is True
 
 
 def test_t2266_dps_codes(mock_t2266_robovac) -> None:


### PR DESCRIPTION
…hardware)

Follow-up to #561. The T2266 docstring asked for real-device proof before enabling the two protocol-3.5 flags — I own a T2266 ("eufy Clean X8 Pro Hybrid" per the eufy cloud) and can confirm it needs both, exactly like the T2276.

Without the flags (main @ 2cd9de8 as shipped): session key negotiation succeeds, but every DPS query returns no data points and the device closes the connection ~30 s after connect, in a loop: 17:23:51 Connecting to …cblyna (192.168.3.x:6668)
17:23:51 Session key negotiated successfully
17:23:51 Vacuum has no data points available yet
17:24:22 Incomplete read (0 bytes partial): empty
17:24:22 Connection closed by device (EOF)   ← repeats every ~30 s
With both flags enabled: the full DPS set arrives (1, 2, 5, 15, 101-113, 115, 118, 122, 124, 126-137, 142), push updates land every ~10 s, and the connection stays up. Verified working over several hours: state/battery/error sensors, locate (DPS 103), start/pause (DPS 2), return home (DPS 101), fan speeds (DPS 102), and roomClean via DPS 124 selectRoomsClean (incl. the result: "O"/"F" ACK).

Test environment: HA 2026.7.4 (HAOS), integration at main (2cd9de8), local network, eufy cloud login for key retrieval.

Transparency note: I debugged this together with an AI assistant (Claude), but everything above was executed and verified live against my own robot — happy to re-run anything or provide fuller debug logs.