### PR TITLE
fix: send boolean return-home command for T2190 and T2259

### DIFF
--- a/custom_components/robovac/vacuums/T2190.py
+++ b/custom_components/robovac/vacuums/T2190.py
@@ -56,6 +56,7 @@ class T2190(RobovacModelDetails):
         },
         RobovacCommand.RETURN_HOME: {
             "code": 101,
+            "values": {"return": True},
         },
         RobovacCommand.FAN_SPEED: {
             "code": 102,

--- a/custom_components/robovac/vacuums/T2259.py
+++ b/custom_components/robovac/vacuums/T2259.py
@@ -50,6 +50,7 @@ class T2259(RobovacModelDetails):
         },
         RobovacCommand.RETURN_HOME: {
             "code": 101,
+            "values": {"return": True},
         },
         RobovacCommand.FAN_SPEED: {
             "code": 102,

--- a/tests/test_vacuum/test_vacuum_commands.py
+++ b/tests/test_vacuum/test_vacuum_commands.py
@@ -70,6 +70,30 @@ async def test_async_return_to_base(mock_robovac, mock_vacuum_data) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("model_code", ["T2190", "T2259"])
+async def test_async_return_to_base_sends_boolean_payload_for_t2190_and_t2259(
+    mock_vacuum_data,
+    model_code,
+) -> None:
+    """T2190 and T2259 return home through boolean DPS 101."""
+    with patch("custom_components.robovac.robovac.TuyaDevice.__init__", return_value=None):
+        robovac = RoboVac(
+            model_code=model_code,
+            device_id="test_id",
+            host="192.168.1.100",
+            local_key="test_key",
+        )
+    robovac.async_set = AsyncMock(return_value=True)
+
+    model_data = {**mock_vacuum_data, CONF_MODEL: model_code}
+    with patch("custom_components.robovac.vacuum.RoboVac", return_value=robovac):
+        entity = RoboVacEntity(model_data)
+        await entity.async_return_to_base()
+
+    robovac.async_set.assert_awaited_once_with({"101": True})
+
+
+@pytest.mark.asyncio
 async def test_async_start(mock_robovac, mock_vacuum_data) -> None:
     """Test the async_start method."""
     # Arrange


### PR DESCRIPTION
## Summary

- Send the contributor-tested boolean return-home payload on DPS 101 for T2190 and T2259.
- Exercise the real RoboVacEntity return-to-base operation for both models.

## Verification

- task lint
- task type-check
- task test (759 tests pass at the stack tip)

## Stack

1 of 4. Base: main. Next: #594.

Closes #397.

---
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>