### PR TITLE
fix: send boolean return-home command for T2193

### DIFF
--- a/custom_components/robovac/vacuums/T2193.py
+++ b/custom_components/robovac/vacuums/T2193.py
@@ -64,6 +64,7 @@ class T2193(RobovacModelDetails):
         },
         RobovacCommand.RETURN_HOME: {
             "code": 101,
+            "values": {"return": True},
         },
         RobovacCommand.FAN_SPEED: {
             "code": 102,

--- a/tests/test_vacuum/test_vacuum_commands.py
+++ b/tests/test_vacuum/test_vacuum_commands.py
@@ -70,12 +70,12 @@ async def test_async_return_to_base(mock_robovac, mock_vacuum_data) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("model_code", ["T2190", "T2259"])
-async def test_async_return_to_base_sends_boolean_payload_for_t2190_and_t2259(
+@pytest.mark.parametrize("model_code", ["T2190", "T2193", "T2259"])
+async def test_async_return_to_base_sends_boolean_payload_for_t2190_t2193_and_t2259(
     mock_vacuum_data,
     model_code,
 ) -> None:
-    """T2190 and T2259 return home through boolean DPS 101."""
+    """T2190, T2193, and T2259 return home through boolean DPS 101."""
     with patch("custom_components.robovac.robovac.TuyaDevice.__init__", return_value=None):
         robovac = RoboVac(
             model_code=model_code,


### PR DESCRIPTION
## Summary

- Send the contributor-tested boolean return-home payload on DPS 101 for T2193.
- Extend the same real RoboVacEntity operation test used by the lower layer.

## Verification

- task lint
- task type-check
- task test (759 tests pass at the stack tip)

## Stack

2 of 4. Depends on #593. Next: #595.

Closes #548.

---
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>