### PR TITLE
fix: advertise supported G10 Hybrid fan speeds

### DIFF
--- a/custom_components/robovac/vacuums/T2150.py
+++ b/custom_components/robovac/vacuums/T2150.py
@@ -55,9 +55,7 @@ class T2150(RobovacModelDetails):
             "code": 102,
             "values": {
                 "standard": "Standard",
-                "turbo": "Turbo",
                 "max": "Max",
-                "boost_iq": "Boost_IQ",
             },
         },
         RobovacCommand.LOCATE: {

--- a/tests/test_vacuum/test_t2150_fan_speeds.py
+++ b/tests/test_vacuum/test_t2150_fan_speeds.py
@@ -1,0 +1,18 @@
+"""Regression coverage for G10 Hybrid fan-speed capabilities."""
+
+from unittest.mock import patch
+
+from custom_components.robovac.robovac import RoboVac
+
+
+def test_t2150_advertises_only_supported_fan_speeds() -> None:
+    """The G10 Hybrid exposes only its Standard and Max choices to Home Assistant."""
+    with patch("custom_components.robovac.robovac.TuyaDevice.__init__", return_value=None):
+        robovac = RoboVac(
+            model_code="T2150",
+            device_id="test_id",
+            host="192.168.1.100",
+            local_key="test_key",
+        )
+
+    assert robovac.getFanSpeeds() == ["Standard", "Max"]


### PR DESCRIPTION
## Summary

- Stop advertising unsupported Turbo and Boost IQ modes for the G10 Hybrid (T2150).
- Keep the Home Assistant fan-speed list to the contributor-confirmed Standard and Max modes.

## Verification

- task lint
- task type-check
- task test (759 tests pass at the stack tip)

## Stack

3 of 4. Depends on #594. Next: #596.

Closes #550.

---
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>