### PR TITLE
fix(T2258): read status from DPS 2, not the stuck DPS 15

### DIFF
--- a/custom_components/robovac/vacuums/T2258.py
+++ b/custom_components/robovac/vacuums/T2258.py
@@ -34,8 +34,18 @@ class T2258(RobovacModelDetails):
                 "spot": "Spot",
             },
         },
+        # DPS 15 is not a usable status register on this model: it reports
+        # "Running" while cleaning, paused, stopped and docked alike, so the
+        # entity never leaves CLEANING. DPS 2 is the datapoint that tracks
+        # whether the vacuum is actually active.
+        #
+        # The values map is required rather than cosmetic. DPS 2 is a boolean,
+        # and a raw False is indistinguishable from "no status" to the
+        # `state == 0` check in RoboVacEntity.activity, which then falls back to
+        # the cleaning mode. Decoding to a string avoids that.
         RobovacCommand.STATUS: {
-            "code": 15,
+            "code": 2,
+            "values": {"True": "cleaning", "False": "docked"},
         },
         RobovacCommand.RETURN_HOME: {
             "code": 101,

--- a/tests/test_vacuum/test_t2258_command_mappings.py
+++ b/tests/test_vacuum/test_t2258_command_mappings.py
@@ -60,6 +60,28 @@ def test_t2258_uses_documented_suction_levels(mock_t2258_robovac) -> None:
     ) == "Boost_IQ"
 
 
+def test_t2258_reads_status_from_dps_2(mock_t2258_robovac) -> None:
+    """Test T2258 takes status from DPS 2 rather than the stuck DPS 15."""
+    status = mock_t2258_robovac.model_details.commands[RobovacCommand.STATUS]
+
+    assert status["code"] == 2
+
+
+def test_t2258_decodes_status_to_activity_strings(mock_t2258_robovac) -> None:
+    """Test the boolean on DPS 2 decodes to a string, not a raw bool.
+
+    A raw False reaching RoboVacEntity.activity is caught by its `state == 0`
+    check and falls back to the cleaning mode, so the decode is what keeps a
+    stopped vacuum from reporting as cleaning.
+    """
+    assert mock_t2258_robovac.getRoboVacHumanReadableValue(
+        RobovacCommand.STATUS, True
+    ) == "cleaning"
+    assert mock_t2258_robovac.getRoboVacHumanReadableValue(
+        RobovacCommand.STATUS, False
+    ) == "docked"
+
+
 def test_t2258_does_not_expose_direction_command(mock_t2258_robovac) -> None:
     """Test T2258 does not expose undocumented manual direction controls."""
     assert RobovacCommand.DIRECTION not in mock_t2258_robovac.model_details.commands


### PR DESCRIPTION
## Problem

On a G20 Hybrid (T2258), `vacuum.<name>` reports `cleaning` permanently. It never shows `docked`, `paused` or `idle`, whatever the vacuum is actually doing.

The T2258 profile was added from eufy's published manuals rather than from a device (#522, #533). This is, as far as I can tell, the first time it has been run against real hardware, and two of the mapping assumptions do not hold.

## Evidence

DPS 15, which the profile uses as `STATUS`, reports `Running` in **every** state. Raw datapoints straight off the device, with only the state changed between samples:

| Vacuum state | DPS 2 | DPS 15 | DPS 122 |
|---|---|---|---|
| cleaning | `True` | `Running` | `Continue` |
| paused (`vacuum.pause`) | `False` | `Running` | `Nosweep` |
| stopped (`vacuum.stop`) | `False` | `Running` | `Nosweep` |
| returning to dock | `True` | `Running` | `Nosweep` |
| docked, idle | `False` | `Running` | `Nosweep` |

It still reads `Running` after a day on the dock, and still reads `Running` on a **freshly established connection** — I reloaded the config entry to force a new session, so this is the device reporting it, not a stale cache in the integration.

Because `Running` matches none of the recognised statuses, `RoboVacEntity.activity` falls through to its final `else` and returns `CLEANING`.

## Fix

Read `STATUS` from DPS 2, which does track whether the vacuum is active.

Two details in the change are load-bearing, and both cost me a while to work out:

**The `values` map is required, not cosmetic.** DPS 2 is a boolean. A raw `False` returned from `getRoboVacHumanReadableValue` hits this check in `activity`:

```python
if self._attr_tuya_state is None or self._attr_tuya_state == 0:
```

`False == 0` is `True` in Python, so a stopped vacuum is treated as having *no* status and falls back to the mode activity. **This means a boolean status datapoint cannot be expressed through `activity_mapping` alone** — the mapping is never consulted. Decoding to a string first is what avoids it. That may be worth addressing in the shared logic separately; I've kept this PR to the model file.

**Mapping `False` to `docked` rather than `idle` is deliberate.** `activity` prefers the mode activity over an `idle` status:

```python
if activity == VacuumActivity.IDLE and mode_activity not in (None, VacuumActivity.IDLE):
    return mode_activity
```

and `_activity_from_mode` maps cleaning mode `auto` to `CLEANING`. On this model DPS 5 is a persistent *mode setting*, not a statement about what the machine is doing, so an `idle` status would still be overridden back to `cleaning`.

## Verified on hardware

After the change, on the actual vacuum: docked → `docked`, `vacuum.start` → `cleaning`, back to `docked` once it redocks. Every command was also exercised and works — `start`, `pause`, `stop`, `return_to_base`, `locate`, `set_fan_speed`; battery and error decode correctly. (`clean_spot` untested.)

## Known limitation

DPS 2 cannot separate docked from paused-mid-floor, so a pause reports as `docked`, and a return-to-dock reports as `cleaning` until the vacuum arrives.

DPS 122 (`Continue` while sweeping, `Nosweep` otherwise) would disambiguate these, but combining two datapoints isn't expressible through the current single-DPS `STATUS` hook. Happy to look at that if you'd want it.

## Tests

Two added to `tests/test_vacuum/test_t2258_command_mappings.py`, covering the DPS code and the boolean decode. Full suite passes locally (760 passed).

## Note

Happy to rework this if you'd prefer a different shape — e.g. going through `activity_mapping` with a non-activity vocabulary (`"running"` / `"standby"`) instead of decoding straight to activity strings. I went with what I could verify against the hardware in front of me.
